### PR TITLE
repro. website benchmarks with benchmarking script

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -116,6 +116,18 @@ var steadyStateDuration = flag.Duration(
 	"how long to run the benchmark for at steady-state. if 0, will run indefinitely",
 )
 
+var steadyStateRepeatTimes = flag.Int(
+	"steady-state-repeat-times",
+	1,
+	"number of times to repeat the steady-state phase",
+)
+
+var steadyStatePurgeCacheBefore = flag.Bool(
+	"steady-state-purge-cache-before",
+	false,
+	"purge the cache of all namespaces before starting a steady-state phase",
+)
+
 var hostHeader = flag.String(
 	"host-header",
 	"",


### PR DESCRIPTION
Plan here is to:
- Upsert 1M documents (vectors or text) to a single namespace
- Wait for it to be fully indexed
- Do 10 steady state runs, each one running for 30s or so, purging the cache before each iteration
- Report combined results