### PR TITLE
Various benchmark enhancements

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -102,6 +102,12 @@ var benchmarkPurgeCache = flag.Bool(
 	"purge the cache before starting the benchmark",
 )
 
+var benchmarkWarmCache = flag.Bool(
+	"warm-cache",
+	false,
+	"warm the cache before starting the benchmark",
+)
+
 var benchmarkQueriesPerSecond = flag.Float64(
 	"queries-per-sec",
 	3.0,

--- a/flags.go
+++ b/flags.go
@@ -90,6 +90,12 @@ var logNormalSigma = flag.Float64(
 
 // Benchmark settings
 
+var benchmarkPromptToClear = flag.Bool(
+	"prompt-to-clear",
+	true,
+	"prompt the user to clear non-empty namespaces before starting the benchmark",
+)
+
 var benchmarkWaitForIndexing = flag.Bool(
 	"wait-for-indexing",
 	true,

--- a/flags.go
+++ b/flags.go
@@ -129,7 +129,7 @@ var benchmarkQueryConcurrency = flag.Int(
 var benchmarkQueryDistribution = flag.String(
 	"query-distribution",
 	"uniform",
-	"distribution of queries across namespaces. options: 'uniform', 'pareto'",
+	"distribution of queries across namespaces. options: 'uniform', 'pareto', 'round-robin'",
 )
 
 var benchmarkQueryParetoAlpha = flag.Float64(

--- a/flags.go
+++ b/flags.go
@@ -108,6 +108,12 @@ var benchmarkQueriesPerSecond = flag.Float64(
 	"combined queries per second across all namespaces. see: `query-distribution`",
 )
 
+var benchmarkQueryConcurrency = flag.Int(
+	"query-concurrency",
+	8,
+	"the number of concurrent queries to run",
+)
+
 var benchmarkQueryDistribution = flag.String(
 	"query-distribution",
 	"uniform",
@@ -130,6 +136,12 @@ var benchmarkUpsertsPerSecond = flag.Int(
 	"upserts-per-sec",
 	5,
 	"combined upserts per second across all namespaces. will respect `upsert-min-batch-size` and `upsert-max-batch-size`",
+)
+
+var benchmarkUpsertConcurrency = flag.Int(
+	"upsert-concurrency",
+	8,
+	"the number of concurrent upserts to run",
 )
 
 var upsertBatchSize = flag.Int(

--- a/main.go
+++ b/main.go
@@ -416,6 +416,10 @@ func setupNamespaces(
 		totalExisting += int64(s)
 	}
 	if totalExisting > 0 {
+		if !*benchmarkPromptToClear {
+			log.Printf("skipping setup phase, proceeding with benchmark")
+			return namespaces, existingSizes, nil
+		}
 		log.Printf("found %d existing documents in namespaces", totalExisting)
 		log.Printf("would you like to delete them before proceeding? (yes/no/cancel)")
 		log.Printf(

--- a/main.go
+++ b/main.go
@@ -608,7 +608,7 @@ func purgeCache(ctx context.Context, namespaces ...*Namespace) error {
 // off from a warm cache.
 func warmCache(ctx context.Context, namespaces ...*Namespace) error {
 	eg := new(errgroup.Group)
-	eg.SetLimit(100)
+	eg.SetLimit(1)
 	for _, ns := range namespaces {
 		eg.Go(func() error {
 			if err := ns.WarmCache(ctx); err != nil {
@@ -665,6 +665,8 @@ func generateQueryLoad(ctx context.Context, sizes []int) (<-chan int, error) {
 	switch *benchmarkQueryDistribution {
 	case "uniform":
 		queryDistribution = NewUniformQueryDistribution(len(indexes))
+	case "round-robin":
+		queryDistribution = NewRoundRobinQueryDistribution(len(indexes))
 	case "pareto":
 		alpha := *benchmarkQueryParetoAlpha
 		if alpha < 0 {

--- a/main.go
+++ b/main.go
@@ -608,7 +608,7 @@ func purgeCache(ctx context.Context, namespaces ...*Namespace) error {
 // off from a warm cache.
 func warmCache(ctx context.Context, namespaces ...*Namespace) error {
 	eg := new(errgroup.Group)
-	eg.SetLimit(1)
+	eg.SetLimit(100)
 	for _, ns := range namespaces {
 		eg.Go(func() error {
 			if err := ns.WarmCache(ctx); err != nil {

--- a/namespace.go
+++ b/namespace.go
@@ -115,6 +115,24 @@ func (n *Namespace) PurgeCache(ctx context.Context) error {
 	return nil
 }
 
+// WarmCache warms the cache for the namespace, i.e. it ensures that the
+// namespace is in a warm state when the benchmark begins.
+func (n *Namespace) WarmCache(ctx context.Context) error {
+	response, err := n.request(
+		ctx,
+		http.MethodGet,
+		fmt.Sprintf("/v1/namespaces/%s/_debug/warm_cache", n.name),
+		nil,
+	)
+	if err != nil {
+		if response != nil && response.Status == http.StatusNotFound {
+			return nil
+		}
+		return fmt.Errorf("failed to warm cache: %w", err)
+	}
+	return nil
+}
+
 // Upsert upserts a number of documents into the namespace, generating
 // the documents using its upsert template. The caller must be aware of
 // batch sizes, and tune accordingly (i.e. the API may not accept more

--- a/query_distribution.go
+++ b/query_distribution.go
@@ -30,6 +30,23 @@ func (u *UniformQueryDistribution) NextIndex() int {
 	return rand.Intn(u.n)
 }
 
+// RoundRobinQueryDistribution is a QueryDistribution that generates
+// indices in a round-robin fashion.
+type RoundRobinQueryDistribution struct {
+	n   int
+	idx int
+}
+
+// NewRoundRobinQueryDistribution creates a new RoundRobinQueryDistribution.
+func NewRoundRobinQueryDistribution(n int) *RoundRobinQueryDistribution {
+	return &RoundRobinQueryDistribution{n: n, idx: -1}
+}
+
+func (r *RoundRobinQueryDistribution) NextIndex() int {
+	r.idx = (r.idx + 1) % r.n
+	return r.idx
+}
+
 // ParetoQueryDistribution is a QueryDistribution that generates
 // indices according to a Pareto distribution.
 //

--- a/reporter.go
+++ b/reporter.go
@@ -195,8 +195,9 @@ func (r *Reporter) maybePrintReport() {
 		report.MergeOther(ur)
 	}
 
+	runtime := now.Sub(r.firstReportTime).Round(time.Second)
 	fmt.Println("")
-	fmt.Printf("Report for the last %s:\n", r.printInterval)
+	fmt.Printf("(%s) Report for the last %s:\n", runtime, r.printInterval)
 	report.PrintWithDepth(0)
 
 	r.lastReportTime = now

--- a/reporter.go
+++ b/reporter.go
@@ -19,9 +19,10 @@ import (
 // files.
 type Reporter struct {
 	sync.Mutex
-	outputDir      string
-	printInterval  time.Duration
-	lastReportTime time.Time
+	outputDir       string
+	printInterval   time.Duration
+	firstReportTime time.Time
+	lastReportTime  time.Time
 
 	// Individual reporters
 	queries *queryReporter
@@ -111,11 +112,12 @@ func (r *Reporter) Stop() error {
 	var (
 		finalReport    = make(Report)
 		overAllPeriods = true
+		dur            = time.Since(r.firstReportTime)
 	)
-	if report := r.queries.generateReport(overAllPeriods); len(report) > 0 {
+	if report := r.queries.generateReport(overAllPeriods, dur); len(report) > 0 {
 		finalReport.MergeOther(report)
 	}
-	if report := r.upserts.generateReport(overAllPeriods); len(report) > 0 {
+	if report := r.upserts.generateReport(overAllPeriods, dur); len(report) > 0 {
 		finalReport.MergeOther(report)
 	}
 
@@ -172,21 +174,24 @@ func (r *Reporter) ReportUpsert(
 // maybePrintReport prints a report if the print interval has elapsed.
 // Requires the lock to be held.
 func (r *Reporter) maybePrintReport() {
+	now := time.Now()
 	if time.Since(r.lastReportTime) < r.printInterval {
 		return
-	} else if r.lastReportTime.IsZero() {
-		r.lastReportTime = time.Now()
+	} else if r.firstReportTime.IsZero() {
+		r.firstReportTime = now
+		r.lastReportTime = now
 		return
 	}
 
 	var (
 		report         = make(Report)
 		overAllPeriods = false
+		dur            = now.Sub(r.lastReportTime)
 	)
-	if qr := r.queries.generateReport(overAllPeriods); len(qr) > 0 {
+	if qr := r.queries.generateReport(overAllPeriods, dur); len(qr) > 0 {
 		report.MergeOther(qr)
 	}
-	if ur := r.upserts.generateReport(overAllPeriods); len(ur) > 0 {
+	if ur := r.upserts.generateReport(overAllPeriods, dur); len(ur) > 0 {
 		report.MergeOther(ur)
 	}
 
@@ -194,7 +199,7 @@ func (r *Reporter) maybePrintReport() {
 	fmt.Printf("Report for the last %s:\n", r.printInterval)
 	report.PrintWithDepth(0)
 
-	r.lastReportTime = time.Now()
+	r.lastReportTime = now
 	r.queries.advanceReportingWindow()
 	r.upserts.advanceReportingWindow()
 }
@@ -275,7 +280,7 @@ func (qr *queryReporter) reportQuery(
 	return nil
 }
 
-func (qr *queryReporter) generateReport(allReportingPeriods bool) Report {
+func (qr *queryReporter) generateReport(allReportingPeriods bool, dur time.Duration) Report {
 	report := make(Report)
 	for temp, latencies := range qr.queryLatencies {
 		// Generate a combined set of latencies
@@ -311,8 +316,9 @@ func (qr *queryReporter) generateReport(allReportingPeriods bool) Report {
 		latencies.WriteString(fmt.Sprintf(", max=%dms", percentile(1.0)))
 
 		report[fmt.Sprintf("%s_queries", temp)] = Report{
-			"count":     int64(len(combined)),
-			"latencies": latencies.String(),
+			"count":      int64(len(combined)),
+			"throughput": float64(len(combined)) / dur.Seconds(),
+			"latencies":  latencies.String(),
 		}
 	}
 
@@ -398,7 +404,7 @@ func (ur *upsertReporter) reportUpsert(
 	return nil
 }
 
-func (ur *upsertReporter) generateReport(allReportingPeriods bool) Report {
+func (ur *upsertReporter) generateReport(allReportingPeriods bool, dur time.Duration) Report {
 	var combined []UpsertStats
 	if allReportingPeriods {
 		combined = combineUpsertStats(ur.upserts)
@@ -445,6 +451,7 @@ func (ur *upsertReporter) generateReport(allReportingPeriods bool) Report {
 			"num_requests":  int64(len(combined)),
 			"num_documents": totalDocs,
 			"total_bytes":   totalBytes,
+			"throughput":    float64(len(combined)) / dur.Seconds(),
 			"latencies":     latencies.String(),
 		},
 	}

--- a/templates/document_attrs.json.tmpl
+++ b/templates/document_attrs.json.tmpl
@@ -1,0 +1,9 @@
+{
+    "id": {{ id }},
+    "vector": {{ vector 768 }},
+    "attributes": {
+        "attr1": "{{ string_with_cardinality 1 10 }}",
+        "attr2": "{{ string 32 }}",
+        "attr3": "{{ string 16 }}"
+    }
+}

--- a/templates/query_attrs.json.tmpl
+++ b/templates/query_attrs.json.tmpl
@@ -1,0 +1,9 @@
+{
+    "top_k": 10,
+    "vector": {{ vector 768 }},
+    "filter": ["attr1", "Eq", "a"],
+    "include_attributes": [
+        "attr2",
+        "attr3"
+    ]
+}


### PR DESCRIPTION
See individual commits.

I'm happy to pull out any controversial ones into separate PRs for discussion. For example, the first one moves the workload from an open-loop to a closed-loop with a fixed client concurrency, which is more appropriate for finding a throughput maximum. However, we may still want to retain an open-loop mode.