### PR TITLE
Port to official Go SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module playground
 go 1.23.3
 
 require (
-	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/google/uuid v1.6.0
 	github.com/schollz/progressbar/v3 v3.18.0
+	github.com/turbopuffer/turbopuffer-go v0.1.0-beta.1
 	github.com/xitongsys/parquet-go v1.6.2
 	github.com/xitongsys/parquet-go-source v0.0.0-20241021075129-b732d2ac9c9b
 	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8
@@ -21,6 +21,10 @@ require (
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/pierrec/lz4/v4 v4.1.8 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/tidwall/gjson v1.14.4 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/term v0.28.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,6 @@ github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnw
 github.com/aws/smithy-go v1.17.0/go.mod h1:NukqUGpCZIILqqiV0NIjeFh24kd/FAa4beRb6nbIUPE=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bobg/gcsobj v0.1.2/go.mod h1:vS49EQ1A1Ib8FgrL58C8xXYZyOCR2TgzAdopy6/ipa8=
-github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
-github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -486,6 +484,18 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
+github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
+github.com/turbopuffer/turbopuffer-go v0.1.0-beta.1 h1:H60aRNxBhDiSKuoNgPAN9SGwO7J2b8zd2kQtfjvHaIU=
+github.com/turbopuffer/turbopuffer-go v0.1.0-beta.1/go.mod h1:ohbenQPvF+CrgCUL7tDAJGL0qP7aCIJWo93fULzFZeg=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/xitongsys/parquet-go v1.5.1/go.mod h1:xUxwM8ELydxh4edHGegYq1pA8NnMKDx0K/GyB0o2bww=

--- a/namespace.go
+++ b/namespace.go
@@ -2,26 +2,23 @@ package main
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
-	"strings"
 	"text/template"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
+	"github.com/turbopuffer/turbopuffer-go"
+	"github.com/turbopuffer/turbopuffer-go/packages/respjson"
 )
 
 // Namespace is a handle to a turbopuffer namespace, and is used
 // to perform requests against the namespace.
 type Namespace struct {
-	name   string
-	client *http.Client
+	client *turbopuffer.Client
+	inner  turbopuffer.Namespace
 
 	// Templates for upsert and query requests
 	queryTmpl  *template.Template
@@ -33,30 +30,31 @@ type Namespace struct {
 // The namespace will use the provided HTTP client to make requests.
 func NewNamespace(
 	ctx context.Context,
-	client *http.Client,
+	client *turbopuffer.Client,
 	name string,
 	queryTmpl, docTmpl, upsertTmpl *template.Template,
 ) *Namespace {
 	return &Namespace{
-		name:       name,
 		client:     client,
+		inner:      client.Namespace(name),
 		queryTmpl:  queryTmpl,
 		docTmpl:    docTmpl,
 		upsertTmpl: upsertTmpl,
 	}
 }
 
+// ID reports the ID of the namespace.
+func (n *Namespace) ID() string {
+	return n.inner.ID()
+}
+
 // Clear deletes all documents from the namespace, effectively resetting
 // it to an empty state. This will delete all documents in the namespace.
 func (n *Namespace) Clear(ctx context.Context) error {
-	response, err := n.request(
-		ctx,
-		http.MethodDelete,
-		"/v1/namespaces/"+n.name,
-		nil,
-	)
+	_, err := n.inner.DeleteAll(ctx, turbopuffer.NamespaceDeleteAllParams{})
 	if err != nil {
-		if response != nil && response.Status == http.StatusNotFound {
+		var apiErr *turbopuffer.Error
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
 			return nil // Namespace doesn't exist, nothing to clear
 		}
 		return fmt.Errorf("failed to clear namespace: %w", err)
@@ -67,47 +65,30 @@ func (n *Namespace) Clear(ctx context.Context) error {
 // CurrentSize queries the namespace for its current size, i.e. the
 // number of documents it contains.
 func (n *Namespace) CurrentSize(ctx context.Context) (int64, error) {
-	response, err := n.request(
-		ctx,
-		http.MethodHead,
-		"/v1/namespaces/"+n.name,
-		nil,
-	)
+	response, err := n.inner.Query(ctx, turbopuffer.NamespaceQueryParams{
+		AggregateBy: map[string]turbopuffer.AggregateBy{
+			"count": turbopuffer.NewAggregateByCount("id"),
+		},
+	})
 	if err != nil {
-		if response != nil && response.Status == http.StatusNotFound {
+		var apiErr *turbopuffer.Error
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
 			return 0, nil
 		}
 		return 0, fmt.Errorf("failed to get namespace size: %w", err)
 	}
-
-	if response.Status == http.StatusNotFound {
-		return 0, nil
-	}
-
-	var numDocuments int64
-	if headerValue := response.Headers.Get("X-turbopuffer-Approx-Num-Vectors"); headerValue != "" {
-		numDocuments, err = strconv.ParseInt(headerValue, 10, 64)
-		if err != nil {
-			return 0, fmt.Errorf("failed to parse namespace size: %w", err)
-		}
-	} else {
-		return 0, fmt.Errorf("missing X-turbopuffer-Approx-Num-Vectors header")
-	}
-
-	return numDocuments, nil
+	count := response.Aggregations["count"].(respjson.Number)
+	return count.Int64()
 }
 
 // PurgeCache purges the cache for the namespace, i.e. it ensures that
 // the namespace is in a cold state when the benchmark begins.
 func (n *Namespace) PurgeCache(ctx context.Context) error {
-	response, err := n.request(
-		ctx,
-		http.MethodGet,
-		fmt.Sprintf("/v1/namespaces/%s/_debug/purge_cache", n.name),
-		nil,
-	)
+	url := fmt.Sprintf("/v1/namespaces/%s/_debug/purge_cache", n.ID())
+	err := n.client.Get(ctx, url, nil, nil)
 	if err != nil {
-		if response != nil && response.Status == http.StatusNotFound {
+		var apiErr *turbopuffer.Error
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
 			return nil
 		}
 		return fmt.Errorf("failed to purge cache: %w", err)
@@ -118,25 +99,9 @@ func (n *Namespace) PurgeCache(ctx context.Context) error {
 // WarmCache warms the cache for the namespace, i.e. it ensures that the
 // namespace is in a warm state when the benchmark begins.
 func (n *Namespace) WarmCache(ctx context.Context) error {
-	warmCacheFn := func() error {
-		response, err := n.request(
-			ctx,
-			http.MethodGet,
-			fmt.Sprintf("/v1/namespaces/%s/_debug/warm_cache", n.name),
-			nil,
-		)
-		if err != nil {
-			if response != nil && response.Status == http.StatusTooManyRequests {
-				return err // Retryable
-			}
-			return backoff.Permanent(fmt.Errorf("failed to warm cache: %w", err))
-		}
-		return nil
-	}
-	if err := backoff.Retry(warmCacheFn, backoff.WithContext(backoff.NewExponentialBackOff(), ctx)); err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return nil
-		}
+	url := fmt.Sprintf("/v1/namespaces/%s/_debug/warm_cache", n.ID())
+	err := n.client.Get(ctx, url, nil, nil)
+	if err != nil {
 		return fmt.Errorf("failed to warm cache: %w", err)
 	}
 	return nil
@@ -199,6 +164,15 @@ func (msr *MultiSliceReader) Read(p []byte) (n int, err error) {
 	return cl, nil
 }
 
+func readerOverSlices(slices [][]byte) io.ReadCloser {
+	if len(slices) == 0 {
+		return nil
+	} else if len(slices) == 1 {
+		return io.NopCloser(bytes.NewReader(slices[0]))
+	}
+	return io.NopCloser(&MultiSliceReader{slices: slices})
+}
+
 // UpsertPrerendered is the same as `Upsert()`, but instead of generating
 // the documents using the upsert template, it takes the upsert request body
 // as a parameter. This is used for pre-rendered documents, i.e. when we
@@ -214,45 +188,19 @@ func (n *Namespace) UpsertPrerendered(
 		totalByteSize += len(chunk)
 	}
 
-	upsertFn := func() error {
-		if resp, err := n.request(
-			ctx,
-			http.MethodPost,
-			"/v1/namespaces/"+n.name,
-			upsertChunks,
-		); err != nil {
-			if resp != nil && resp.Status == http.StatusTooManyRequests {
-				return err // Retryable
-			}
-			return backoff.Permanent(fmt.Errorf("failed to upsert documents: %w", err))
-		}
-		return nil
-	}
-
-	if err := backoff.Retry(upsertFn, backoff.WithContext(backoff.NewExponentialBackOff(), ctx)); err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return time.Since(start), totalByteSize, nil
-		}
+	url := fmt.Sprintf("/v1/namespaces/%s", n.ID())
+	if err := n.client.Post(ctx, url, readerOverSlices(upsertChunks), nil); err != nil {
 		return 0, 0, fmt.Errorf("failed to upsert documents: %w", err)
 	}
 
 	return time.Since(start), totalByteSize, nil
 }
 
-// ServerTiming is a struct that holds timing information sent back by the server
-// after a query. We use this to report query performance.
-type ServerTiming struct {
-	CacheHitRatio    *float64
-	CacheTemperature *CacheTemperature
-	ProcessingTimeMs *uint64
-	ExhaustiveCount  *int64
-}
-
 // Query queries the namespace for a given query, generating the query
 // using its query template. Returns server timing information as well as
 // client time duration if successful, i.e. we don't care about the actual
 // query result.
-func (n *Namespace) Query(ctx context.Context) (*ServerTiming, time.Duration, error) {
+func (n *Namespace) Query(ctx context.Context) (*turbopuffer.QueryPerformance, time.Duration, error) {
 	var buf bytes.Buffer
 	if err := n.queryTmpl.Execute(&buf, nil); err != nil {
 		return nil, 0, fmt.Errorf("failed to execute query template: %w", err)
@@ -260,14 +208,11 @@ func (n *Namespace) Query(ctx context.Context) (*ServerTiming, time.Duration, er
 
 	start := time.Now()
 
-	response, err := n.request(
-		ctx,
-		http.MethodPost,
-		"/v1/namespaces/"+n.name+"/query",
-		[][]byte{buf.Bytes()},
-	)
-	if err != nil {
-		if response != nil && response.Status == http.StatusNotFound {
+	url := fmt.Sprintf("/v1/namespaces/%s/query", n.ID())
+	var response turbopuffer.NamespaceQueryResponse
+	if err := n.client.Post(ctx, url, buf, &response); err != nil {
+		var apiErr *turbopuffer.Error
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
 			return nil, 0, nil
 		}
 		return nil, 0, fmt.Errorf("failed to query namespace: %w", err)
@@ -275,15 +220,7 @@ func (n *Namespace) Query(ctx context.Context) (*ServerTiming, time.Duration, er
 
 	elapsed := time.Since(start)
 
-	var serverTiming *ServerTiming
-	if timing := response.Headers.Get("Server-Timing"); timing != "" {
-		serverTiming, err = parseServerTiming(timing)
-		if err != nil {
-			return nil, 0, fmt.Errorf("failed to parse server timing: %w", err)
-		}
-	}
-
-	return serverTiming, elapsed, nil
+	return &response.Performance, elapsed, nil
 }
 
 // CacheTemperature is an enum over the possible cache temperatures
@@ -314,152 +251,4 @@ func AllCacheTemperatures() []CacheTemperature {
 		CacheTemperatureWarm,
 		CacheTemperatureHot,
 	}
-}
-
-func parseServerTiming(timing string) (*ServerTiming, error) {
-	var ret ServerTiming
-	for _, section := range strings.Split(timing, ", ") {
-		keys := strings.Split(section, ";")
-		if len(keys) == 0 {
-			return nil, fmt.Errorf("invalid server timing section: %s", section)
-		}
-		key := keys[0]
-		for _, part := range keys[1:] {
-			part, value, ok := strings.Cut(part, "=")
-			if !ok {
-				return nil, fmt.Errorf("invalid server timing part: %s", part)
-			}
-			switch key + "." + part {
-			case "cache.hit_ratio":
-				parsed, err := strconv.ParseFloat(value, 32)
-				if err != nil {
-					return nil, fmt.Errorf("failed to parse cache hit ratio: %w", err)
-				}
-				ret.CacheHitRatio = &parsed
-			case "cache.temperature":
-				ct := CacheTemperature(value)
-				if !ct.Valid() {
-					return nil, fmt.Errorf("invalid cache temperature: %s", value)
-				}
-				ret.CacheTemperature = &ct
-			case "processing_time.dur":
-				ms, err := strconv.ParseUint(value, 10, 64)
-				if err != nil {
-					return nil, fmt.Errorf("failed to parse processing time: %w", err)
-				}
-				ret.ProcessingTimeMs = &ms
-			case "exhaustive_search.count":
-				count, err := strconv.ParseInt(value, 10, 64)
-				if err != nil {
-					return nil, fmt.Errorf("failed to parse exhaustive count: %w", err)
-				}
-				ret.ExhaustiveCount = &count
-			}
-		}
-	}
-	return &ret, nil
-}
-
-// Helper type to store the result of a request.
-type ServerResponse struct {
-	Status  int
-	Body    []byte
-	Headers http.Header
-}
-
-func readerOverSlices(slices [][]byte) io.ReadCloser {
-	if len(slices) == 0 {
-		return nil
-	} else if len(slices) == 1 {
-		return io.NopCloser(bytes.NewReader(slices[0]))
-	}
-	return io.NopCloser(&MultiSliceReader{slices: slices})
-}
-
-// Does a request to the namespace, using the provided method and path.
-// If a body is provided, it's assumed to be JSON and is sent as the
-// request body.
-func (n *Namespace) request(
-	ctx context.Context,
-	method, path string,
-	slices [][]byte,
-) (*ServerResponse, error) {
-	endpoint := endpointForPath(path)
-
-	req, err := http.NewRequestWithContext(ctx, method, endpoint, readerOverSlices(slices))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	if *hostHeader != "" {
-		req.Host = *hostHeader
-	}
-	req.Header.Set("Accept-Encoding", "gzip")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiKey))
-	req.Header.Set("User-Agent", "tpuf-benchmark")
-	if len(slices) > 0 {
-		req.Header.Set("Content-Type", "application/json")
-	}
-
-	// For gracefully handling redirects requiring a second body
-	// read. Not super common, but has come up.
-	req.GetBody = func() (io.ReadCloser, error) {
-		return readerOverSlices(slices), nil
-	}
-
-	resp, err := n.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to do request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	var respReader io.Reader = resp.Body
-	if contentEncoding := resp.Header.Get("Content-Encoding"); contentEncoding != "" {
-		switch contentEncoding {
-		case "gzip":
-			var err error
-			respReader, err = gzip.NewReader(resp.Body)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create gzip reader: %w", err)
-			}
-		default:
-			return nil, fmt.Errorf("unsupported content encoding: %s", contentEncoding)
-		}
-	}
-
-	respBody, err := io.ReadAll(respReader)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	response := &ServerResponse{
-		Status:  resp.StatusCode,
-		Body:    respBody,
-		Headers: resp.Header,
-	}
-
-	if resp.StatusCode >= 400 {
-		var apiError struct {
-			Error string `json:"error,omitempty"`
-		}
-		if err := json.Unmarshal(respBody, &apiError); err != nil {
-			apiError.Error = string(respBody)
-		}
-		return response, fmt.Errorf(
-			"api error (status %d): %s",
-			resp.StatusCode,
-			apiError.Error,
-		)
-	}
-
-	return response, nil
-}
-
-func endpointForPath(path string) string {
-	baseUrl := *endpoint
-	if !strings.HasSuffix(baseUrl, "/") {
-		baseUrl += "/"
-	}
-	path = strings.TrimPrefix(path, "/")
-	return baseUrl + path
 }

--- a/namespace.go
+++ b/namespace.go
@@ -208,9 +208,9 @@ func (n *Namespace) Query(ctx context.Context) (*turbopuffer.QueryPerformance, t
 
 	start := time.Now()
 
-	url := fmt.Sprintf("/v1/namespaces/%s/query", n.ID())
+	url := fmt.Sprintf("/v2/namespaces/%s/query", n.ID())
 	var response turbopuffer.NamespaceQueryResponse
-	if err := n.client.Post(ctx, url, buf, &response); err != nil {
+	if err := n.client.Post(ctx, url, buf.Bytes(), &response); err != nil {
 		var apiErr *turbopuffer.Error
 		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
 			return nil, 0, nil

--- a/templates/query_attrs.json.tmpl
+++ b/templates/query_attrs.json.tmpl
@@ -1,6 +1,6 @@
 {
     "top_k": 10,
-    "vector": {{ vector 768 }},
+    "rank_by": ["vector", "ANN", {{ vector 768 }}],
     "filter": ["attr1", "Eq", "a"],
     "include_attributes": [
         "attr2",

--- a/templates/query_default.json.tmpl
+++ b/templates/query_default.json.tmpl
@@ -1,4 +1,4 @@
 {
     "top_k": 10,
-    "vector": {{ vector 768 }}
+    "rank_by": ["vector", "ANN", {{ vector 768 }}]
 }


### PR DESCRIPTION
Now that we have an official Go SDK [0], use it.

This neatly removes a lot of handwritten API call code. We don't get to use the full power of the SDK because this tool renders its own JSON for query and write requests, but that's its own cool validation of the escape hatches that Stainless provides.

Perf looks equivalent to before, in this one relatively unscientific test.

Old (no SDK):

```
$ ./tpuf-benchmark -api-key tpuf_... -endpoint https://gcp-us-central1.turbopuffer.com -namespace-count 100 -namespace-combined-size 1000000 -upserts-per-sec 0 -queries-per-sec 1000     -query-template templates/query_default.json.tmpl -benchmark-duration 60s

clearing namespaces 100% |████████████████████████████████████| (100/100, 113 it/s)        
upserting documents 100% |█████████████████████████| (1000000/1000000, 24135 it/s)         
2025/06/05 19:52:15 waiting for 100 namespace(s) to be indexed before starting benchmark
2025/06/05 19:52:15 all namespaces have been (reasonably) indexed
2025/06/05 19:52:15 starting benchmark, running for 1m0s
2025/06/05 19:52:15 executing queries at 1000.00 QPS (uniform distribution)

Report for the last 10s:
hot_queries:
  count: 9700
  latencies: min=11ms, p10=14ms, p25=16ms, p50=18ms, p75=21ms, p90=25ms, p95=28ms, p99=47ms, max=208ms

Report for the last 10s:
hot_queries:
  count: 9680
  latencies: min=10ms, p10=14ms, p25=15ms, p50=17ms, p75=20ms, p90=23ms, p95=26ms, p99=44ms, max=89ms

Report for the last 10s:
hot_queries:
  count: 9698
  latencies: min=11ms, p10=14ms, p25=15ms, p50=17ms, p75=19ms, p90=22ms, p95=25ms, p99=40ms, max=96ms

Report for the last 10s:
hot_queries:
  count: 9711
  latencies: min=10ms, p10=14ms, p25=15ms, p50=17ms, p75=19ms, p90=22ms, p95=25ms, p99=38ms, max=89ms

Report for the last 10s:
hot_queries:
  count: 9691
  latencies: min=11ms, p10=14ms, p25=15ms, p50=17ms, p75=19ms, p90=22ms, p95=25ms, p99=40ms, max=85ms
2025/06/05 19:53:15 benchmark duration of 1m0s has elapsed, shutting down

Cumulative report for the entire benchmark:
hot_queries:
  count: 58140
  latencies: min=10ms, p10=14ms, p25=15ms, p50=17ms, p75=19ms, p90=23ms, p95=26ms, p99=42ms, max=208ms
2025/06/05 19:53:15 results written to: benchmark-results-1749153088
```

New (with SDK):

```
clearing namespaces 100% |████████████████████████████████████| (100/100, 169 it/s)        
upserting documents 100% |█████████████████████████| (1000000/1000000, 27406 it/s)         
2025/06/05 20:31:02 waiting for 100 namespace(s) to be indexed before starting benchmark
2025/06/05 20:31:02 all namespaces have been (reasonably) indexed
2025/06/05 20:31:02 starting benchmark, running for 1m0s
2025/06/05 20:31:02 executing queries at 1000.00 QPS (uniform distribution)

Report for the last 10s:
hot_queries:
  count: 9681
  latencies: min=11ms, p10=14ms, p25=16ms, p50=18ms, p75=21ms, p90=25ms, p95=29ms, p99=45ms, max=86ms

Report for the last 10s:
hot_queries:
  count: 9707
  latencies: min=10ms, p10=14ms, p25=16ms, p50=17ms, p75=20ms, p90=23ms, p95=27ms, p99=46ms, max=124ms

Report for the last 10s:
hot_queries:
  count: 9675
  latencies: min=10ms, p10=14ms, p25=15ms, p50=17ms, p75=19ms, p90=23ms, p95=27ms, p99=44ms, max=78ms

Report for the last 10s:
hot_queries:
  count: 9699
  latencies: min=10ms, p10=14ms, p25=15ms, p50=17ms, p75=19ms, p90=22ms, p95=25ms, p99=42ms, max=69ms

Report for the last 10s:
hot_queries:
  count: 9670
  latencies: min=11ms, p10=14ms, p25=15ms, p50=17ms, p75=19ms, p90=22ms, p95=25ms, p99=40ms, max=71ms
2025/06/05 20:32:02 benchmark duration of 1m0s has elapsed, shutting down

Cumulative report for the entire benchmark:
hot_queries:
  count: 58099
  latencies: min=10ms, p10=14ms, p25=15ms, p50=17ms, p75=20ms, p90=23ms, p95=26ms, p99=44ms, max=124ms
2025/06/05 20:32:02 results written to: benchmark-results-1749155419
```

[0]: https://github.com/turbopuffer/turbopuffer-go