### PR TITLE
Increase the retry limit when upserting documents during namespace setup

### DIFF
--- a/namespace.go
+++ b/namespace.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/turbopuffer/turbopuffer-go"
+	"github.com/turbopuffer/turbopuffer-go/option"
 	"github.com/turbopuffer/turbopuffer-go/packages/respjson"
 )
 
@@ -180,6 +181,7 @@ func readerOverSlices(slices [][]byte) io.ReadCloser {
 func (n *Namespace) UpsertPrerendered(
 	ctx context.Context,
 	upsertChunks [][]byte,
+	opts ...option.RequestOption,
 ) (time.Duration, int, error) {
 	start := time.Now()
 
@@ -189,7 +191,12 @@ func (n *Namespace) UpsertPrerendered(
 	}
 
 	url := fmt.Sprintf("/v1/namespaces/%s", n.ID())
-	if err := n.client.Post(ctx, url, readerOverSlices(upsertChunks), nil); err != nil {
+	if err := n.client.Post(
+		ctx,
+		url,
+		readerOverSlices(upsertChunks),
+		nil,
+		opts...); err != nil {
 		return 0, 0, fmt.Errorf("failed to upsert documents: %w", err)
 	}
 

--- a/upsert.go
+++ b/upsert.go
@@ -11,6 +11,7 @@ import (
 	"text/template"
 
 	"github.com/schollz/progressbar/v3"
+	"github.com/turbopuffer/turbopuffer-go/option"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -138,7 +139,7 @@ func makeProgressOn(
 		for _, docs := range batches {
 			namespace := upserts[i].Namespace
 			eg.Go(func() error {
-				if _, _, err := namespace.UpsertPrerendered(ctx, [][]byte{before, docs.Contents, after}); err != nil {
+				if _, _, err := namespace.UpsertPrerendered(ctx, [][]byte{before, docs.Contents, after}, option.WithMaxRetries(10)); err != nil {
 					return fmt.Errorf("failed to upsert documents: %w", err)
 				}
 				bar.Add(docs.NumDocs)


### PR DESCRIPTION
Allows more time for the indexer backlog to be processed by asynchronous indexing