### PR TITLE
datasource: add BigANN-Deep 1B dataset

### DIFF
--- a/benchmarks/vector-1b-hot.toml
+++ b/benchmarks/vector-1b-hot.toml
@@ -1,0 +1,45 @@
+name = "vectors_1b_hot"
+namespaces = 1
+duration = "30m"
+description = """
+This benchmark evaluates a vector search query with a warm cache, returning
+topk=10 ANN results.
+
+Embeddings come from the Big-ANN Deep dataset. Those vectors 96 dimensions. This
+benchmark artificially expands the dimensions to 1024 through repetition.
+
+When generating queries, the query vectors are pseudorandomly generated.
+"""
+
+[setup]
+wait_for_indexing = true
+warm_cache = true
+wait_for_cache_hit_ratio = 1.00
+document_count = 1_000_000_000
+datasource = "Deep1B"
+document_template = """
+{
+    "id": {{ id }},
+    "vector": {{ vector 1024 }}
+}
+"""
+upsert_template = """
+{
+    "upsert_rows": [
+        {{ .UpsertBatchPlaceholder }}
+    ],
+    "distance_metric": "cosine_distance",
+    "disable_backpressure": true,
+    "schema": {"attr": {"type": "string", "filterable": true}}
+}
+"""
+
+[workload.query.ann]
+qps = 32
+datasource = "random"
+template = """
+{
+    "top_k": 10,
+    "rank_by": ["vector", "ANN", {{ vector 1024 }}]
+}
+"""

--- a/pkg/datasource/datasource.go
+++ b/pkg/datasource/datasource.go
@@ -23,12 +23,13 @@ const (
 	DatasourceRandom                    Kind = "random"
 	DatasourceCohereWikipediaEmbeddings Kind = "CohereWikipediaEmbeddings"
 	DatasourceCohereMSMarco             Kind = "CohereMSMarco"
+	DatasourceDeep1B                    Kind = "Deep1B"
 )
 
 // Valid returns true if the value is a known datasource ID.
 func (v Kind) Valid() bool {
 	switch v {
-	case DatasourceRandom, DatasourceCohereWikipediaEmbeddings, DatasourceCohereMSMarco:
+	case DatasourceRandom, DatasourceCohereWikipediaEmbeddings, DatasourceCohereMSMarco, DatasourceDeep1B:
 		return true
 	default:
 		return false
@@ -40,7 +41,7 @@ func (v Kind) Valid() bool {
 func (v *Kind) UnmarshalText(text []byte) error {
 	s := Kind(strings.TrimSpace(string(text)))
 	if !s.Valid() {
-		return fmt.Errorf("data source must be one of %q, %q, or %q", DatasourceRandom, DatasourceCohereWikipediaEmbeddings, DatasourceCohereMSMarco)
+		return fmt.Errorf("data source must be one of %q, %q, %q, or %q", DatasourceRandom, DatasourceCohereWikipediaEmbeddings, DatasourceCohereMSMarco, DatasourceDeep1B)
 	}
 	*v = s
 	return nil
@@ -54,6 +55,13 @@ type Config struct {
 
 	Seed             uint64
 	VectorDimensions int
+
+	// ParallelDownloadThreshold is the minimum file size in bytes to trigger
+	// parallel chunked downloading. Defaults to 512 MiB when zero.
+	ParallelDownloadThreshold int64
+	// ParallelDownloadChunkSize is the size of each chunk in bytes used during
+	// parallel downloading. Defaults to 512 MiB when zero.
+	ParallelDownloadChunkSize int64
 }
 
 // Make creates a new datasource from the given configuration.
@@ -65,6 +73,8 @@ func Make(ctx context.Context, src Kind, cfg Config) Source {
 		return CohereWikipediaEmbeddings(ctx, cfg)
 	case DatasourceCohereMSMarco:
 		return CohereMSMarco(ctx, cfg)
+	case DatasourceDeep1B:
+		return Deep1B(ctx, cfg)
 	default:
 		panic(fmt.Errorf("unknown datasource %q", src))
 	}

--- a/pkg/datasource/datasource.go
+++ b/pkg/datasource/datasource.go
@@ -56,9 +56,6 @@ type Config struct {
 	Seed             uint64
 	VectorDimensions int
 
-	// ParallelDownloadThreshold is the minimum file size in bytes to trigger
-	// parallel chunked downloading. Defaults to 512 MiB when zero.
-	ParallelDownloadThreshold int64
 	// ParallelDownloadChunkSize is the size of each chunk in bytes used during
 	// parallel downloading. Defaults to 512 MiB when zero.
 	ParallelDownloadChunkSize int64

--- a/pkg/datasource/deep1b.go
+++ b/pkg/datasource/deep1b.go
@@ -200,7 +200,13 @@ func deep1BChunkRequests(totalSize, chunkSize int64) iter.Seq2[string, RangeRequ
 // deep1BChunkIndex extracts the chunk index from a key of the form
 // "deep1b/base.1B.fbin.chunk-NNNN".
 func deep1BChunkIndex(key string) int {
-	_, suffix, _ := strings.Cut(key, ".chunk-")
-	idx, _ := strconv.Atoi(suffix)
+	_, suffix, ok := strings.Cut(key, ".chunk-")
+	if !ok {
+		panic(fmt.Errorf("deep1B: malformed cache file key %q", key))
+	}
+	idx, err := strconv.Atoi(suffix)
+	if err != nil {
+		panic(fmt.Errorf("deep1B: invalid chunk index in key %q: %w", key, err))
+	}
 	return idx
 }

--- a/pkg/datasource/deep1b.go
+++ b/pkg/datasource/deep1b.go
@@ -1,0 +1,206 @@
+package datasource
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"iter"
+	"math"
+	"strconv"
+	"strings"
+	"text/template"
+)
+
+const deep1BURL = "https://storage.yandexcloud.net/yandex-research/ann-datasets/DEEP/base.1B.fbin"
+
+// Deep1B returns a datasource backed by the Yandex Deep1B dataset — 1 billion
+// 96-dimensional float32 vectors stored in a single .fbin file.
+//
+// Chunks are downloaded in parallel and stored as separate cache files.
+func Deep1B(ctx context.Context, cfg Config) Source {
+	return &deep1BSource{dd: newDownloader(cfg)}
+}
+
+type deep1BSource struct {
+	dd *downloader
+}
+
+var _ Source = (*deep1BSource)(nil)
+
+func (d *deep1BSource) FuncMap(ctx context.Context) template.FuncMap {
+	nextVec := lazyPull2(func() iter.Seq2[[]float32, error] {
+		return deep1BVectorIterator(ctx, d.dd)
+	})
+
+	return template.FuncMap{
+		"vector": func(dims int) string {
+			vec, err, ok := nextVec()
+			if !ok {
+				panic("deep1B vector source exhausted")
+			} else if err != nil {
+				panic(err)
+			}
+			return vectorToString(vec, dims)
+		},
+	}
+}
+
+type deep1BMeta struct {
+	dims       int64
+	numVectors int64
+}
+
+// vectorRawFloat32s decodes one .fbin vector: len(b) must be dims * 4.
+func vectorRawFloat32s(b []byte, dims int64) []float32 {
+	vec := make([]float32, dims)
+	for j := range dims {
+		vec[j] = math.Float32frombits(binary.LittleEndian.Uint32(b[int(j)*4:]))
+	}
+	return vec
+}
+
+// deep1BVectorIterator issues a HEAD request to determine file size, then
+// downloads all chunks in parallel via DownloadRanged. A single goroutine
+// processes chunk files in order (stripping the 8-byte .fbin header from chunk
+// 0) and maintaining a carry buffer for vectors that straddle chunk boundaries.
+func deep1BVectorIterator(ctx context.Context, dd *downloader) iter.Seq2[[]float32, error] {
+	return func(yield func([]float32, error) bool) {
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		size, acceptsRanges, err := headRequest(ctx, deep1BURL)
+		if err != nil {
+			yield(nil, fmt.Errorf("deep1B: HEAD request: %w", err))
+			return
+		}
+		if !acceptsRanges {
+			yield(nil, fmt.Errorf("deep1B: server does not support range requests"))
+			return
+		}
+
+		chunkSize := dd.cfg.ParallelDownloadChunkSize
+		if chunkSize == 0 {
+			chunkSize = defaultParallelDownloadChunkSize
+		}
+
+		downloaded := dd.DownloadRanged(ctx,
+			deep1BChunkRequests(size, chunkSize),
+			parallelDownloadWorkers,
+			dd.cfg.Hooks,
+		)
+
+		var (
+			meta    *deep1BMeta
+			vecBuf  []byte // single-vector accumulation buffer
+			filled  int    // bytes written into vecBuf so far
+			nextIdx int
+			buffer  = make(map[int]DownloadResult)
+		)
+
+		// processChunk yields vectors.
+		//
+		// The first chunk requires special handling (extracting and stripping
+		// the file's header, populating meta). Bytes are copied into vecBuf;
+		// each time it fills to vectorBytes a vector is decoded and yielded.
+		// Partial vectors at chunk boundaries survive in vecBuf[:filled].
+		processChunk := func(idx int, res DownloadResult) bool {
+			if res.Err != nil {
+				yield(nil, res.Err)
+				return false
+			}
+			mmapped, err := MemoryMapFile(res.LocalPath)
+			if err != nil {
+				yield(nil, fmt.Errorf("deep1B: mmap chunk %d: %w", idx, err))
+				return false
+			}
+			defer mmapped.Unmap()
+
+			data := mmapped.Data
+
+			// Parse the preamble from chunk 0 and advance data past it.
+			if idx == 0 {
+				if len(data) < 8 {
+					yield(nil, fmt.Errorf("deep1B: chunk 0 too small (%d bytes)", len(data)))
+					return false
+				}
+				meta = &deep1BMeta{
+					numVectors: int64(binary.LittleEndian.Uint32(data[0:4])),
+					dims:       int64(binary.LittleEndian.Uint32(data[4:8])),
+				}
+				data = data[8:]
+				vecBuf = make([]byte, int(meta.dims)*4)
+			}
+
+			vectorBytes := len(vecBuf)
+			for len(data) > 0 {
+				n := copy(vecBuf[filled:], data)
+				filled += n
+				data = data[n:]
+				if filled == vectorBytes {
+					vec := vectorRawFloat32s(vecBuf, meta.dims)
+					if !yield(vec, nil) {
+						return false
+					}
+					filled = 0
+				}
+			}
+			return true
+		}
+
+		// Consume downloaded results, buffering out-of-order arrivals so the
+		// parse worker always sees chunks in sequence. This is required to
+		// ensure that vectors are composed correctly at chunk boundaries.
+		for res := range downloaded {
+			idx := deep1BChunkIndex(res.Key)
+			if idx != nextIdx {
+				buffer[idx] = res
+				continue
+			}
+			if !processChunk(idx, res) {
+				return
+			}
+			nextIdx++
+			for {
+				buffered, ok := buffer[nextIdx]
+				if !ok {
+					break
+				}
+				delete(buffer, nextIdx)
+				if !processChunk(nextIdx, buffered) {
+					return
+				}
+				nextIdx++
+			}
+		}
+	}
+}
+
+// deep1BChunkRequests returns an iterator of (key, RangeRequest) pairs that
+// cover totalSize bytes in chunkSize-byte segments.
+func deep1BChunkRequests(totalSize, chunkSize int64) iter.Seq2[string, RangeRequest] {
+	return func(yield func(string, RangeRequest) bool) {
+		for i := int64(0); ; i++ {
+			start := i * chunkSize
+			if start >= totalSize {
+				return
+			}
+			key := fmt.Sprintf("deep1b/base.1B.fbin.chunk-%04d", i)
+			req := RangeRequest{
+				URL:   deep1BURL,
+				Start: start,
+				End:   min(start+chunkSize-1, totalSize-1),
+			}
+			if !yield(key, req) {
+				return
+			}
+		}
+	}
+}
+
+// deep1BChunkIndex extracts the chunk index from a key of the form
+// "deep1b/base.1B.fbin.chunk-NNNN".
+func deep1BChunkIndex(key string) int {
+	_, suffix, _ := strings.Cut(key, ".chunk-")
+	idx, _ := strconv.Atoi(suffix)
+	return idx
+}

--- a/pkg/datasource/deep1b.go
+++ b/pkg/datasource/deep1b.go
@@ -11,7 +11,7 @@ import (
 	"text/template"
 )
 
-const deep1BURL = "https://turbopuffer-fixtures.storage.googleapis.com/ci/datasets/big-ann-deep/base.1B.fbin"
+const deep1BURL = "https://storage.yandexcloud.net/yandex-research/ann-datasets/DEEP/base.1B.fbin"
 
 // Deep1B returns a datasource backed by the Yandex Deep1B dataset — 1 billion
 // 96-dimensional float32 vectors stored in a single .fbin file.

--- a/pkg/datasource/deep1b.go
+++ b/pkg/datasource/deep1b.go
@@ -11,7 +11,7 @@ import (
 	"text/template"
 )
 
-const deep1BURL = "https://storage.yandexcloud.net/yandex-research/ann-datasets/DEEP/base.1B.fbin"
+const deep1BURL = "https://turbopuffer-fixtures.storage.googleapis.com/ci/datasets/big-ann-deep/base.1B.fbin"
 
 // Deep1B returns a datasource backed by the Yandex Deep1B dataset — 1 billion
 // 96-dimensional float32 vectors stored in a single .fbin file.

--- a/pkg/datasource/download.go
+++ b/pkg/datasource/download.go
@@ -116,46 +116,50 @@ func (d *downloader) maybeDownloadFile(ctx context.Context, key, url string, hoo
 	return fp, nil
 }
 
-func (d *downloader) downloadFile(ctx context.Context, fp, url string, onDownload OnDownload) error {
-	// Download the file (or wait for the inflight download to complete).
-	// Track inflight downloads by URL (not key) so that two datasources
-	// that happen to use the same key for different URLs are not
-	// incorrectly deduplicated.
+// withDedup deduplicates concurrent calls that share the same key. If another
+// goroutine is already executing work for the given key, the caller blocks
+// until that work completes and receives the same error. Otherwise, fn is
+// executed and its result is broadcast to any goroutines that arrived while fn
+// was in-flight.
+func (d *downloader) withDedup(key string, fn func() error) error {
 	if wait := func() chan error {
 		d.mu.Lock()
 		defer d.mu.Unlock()
-		if _, exists := d.mu.downloads[url]; exists {
-			// We're waiting for an existing download.
+		if _, exists := d.mu.downloads[key]; exists {
 			ch := make(chan error)
-			d.mu.downloads[url] = append(d.mu.downloads[url], ch)
+			d.mu.downloads[key] = append(d.mu.downloads[key], ch)
 			return ch
 		}
-		// We're responsible for downloading.
-		d.mu.downloads[url] = []chan error{}
+		d.mu.downloads[key] = []chan error{}
 		return nil
 	}(); wait != nil {
 		return <-wait
 	}
 
-	err := func() error {
-		if err := os.MkdirAll(filepath.Dir(fp), 0755); err != nil {
-			return fmt.Errorf("failed to create cache directory for %s: %w", fp, err)
-		}
-		return downloadFileSequential(ctx, fp, url, onDownload)
-	}()
+	err := fn()
 
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	// Download complete, notify any waiters and remove the entry.
-	chans := d.mu.downloads[url]
-	delete(d.mu.downloads, url)
-	for _, ch := range chans {
+	for _, ch := range d.mu.downloads[key] {
 		select {
 		case ch <- err:
 		default:
 		}
 	}
+	delete(d.mu.downloads, key)
 	return err
+}
+
+func (d *downloader) downloadFile(ctx context.Context, fp, url string, onDownload OnDownload) error {
+	// Track inflight downloads by URL (not key) so that two datasources
+	// that happen to use the same key for different URLs are not
+	// incorrectly deduplicated.
+	return d.withDedup(url, func() error {
+		if err := os.MkdirAll(filepath.Dir(fp), 0755); err != nil {
+			return fmt.Errorf("failed to create cache directory for %s: %w", fp, err)
+		}
+		return downloadFileSequential(ctx, fp, url, onDownload)
+	})
 }
 
 // RangeRequest is a request to download a specific byte range of a URL as its
@@ -194,9 +198,7 @@ func (d *downloader) DownloadRanged(
 	ch := make(chan DownloadResult, concurrency)
 	var wg sync.WaitGroup
 	for range concurrency {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for item := range reqCh {
 				res := DownloadResult{Key: item.key, SourceURL: item.req.URL}
 				fp, err := d.maybeDownloadRangedFile(ctx, item.key, item.req, hooks)
@@ -211,7 +213,7 @@ func (d *downloader) DownloadRanged(
 					return
 				}
 			}
-		}()
+		})
 	}
 	go func() {
 		wg.Wait()
@@ -237,23 +239,8 @@ func (d *downloader) maybeDownloadRangedFile(ctx context.Context, key string, re
 }
 
 func (d *downloader) downloadRangedFile(ctx context.Context, fp string, req RangeRequest, onDownload OnDownload) error {
-	// Deduplicate concurrent downloads of the same range.
 	dedupKey := fmt.Sprintf("%s#%d-%d", req.URL, req.Start, req.End)
-	if wait := func() chan error {
-		d.mu.Lock()
-		defer d.mu.Unlock()
-		if _, exists := d.mu.downloads[dedupKey]; exists {
-			ch := make(chan error)
-			d.mu.downloads[dedupKey] = append(d.mu.downloads[dedupKey], ch)
-			return ch
-		}
-		d.mu.downloads[dedupKey] = []chan error{}
-		return nil
-	}(); wait != nil {
-		return <-wait
-	}
-
-	err := func() error {
+	return d.withDedup(dedupKey, func() error {
 		if err := os.MkdirAll(filepath.Dir(fp), 0755); err != nil {
 			return fmt.Errorf("failed to create cache directory for %s: %w", fp, err)
 		}
@@ -274,44 +261,37 @@ func (d *downloader) downloadRangedFile(ctx context.Context, fp string, req Rang
 		}
 
 		var body io.Reader = resp.Body
-		if onDownload != nil {
-			chunkSize := req.End - req.Start + 1
-			onDownload(req.URL, 0, chunkSize)
+		if onDownload != nil && resp.ContentLength > 0 {
+			onDownload(req.URL, 0, resp.ContentLength)
 			body = &downloadProgressReader{resp: resp, sourceURL: req.URL, onDownload: onDownload}
 		}
 
-		tmp := fp + ".tmp"
-		f, err := os.Create(tmp)
-		if err != nil {
-			return fmt.Errorf("failed to create file %s: %w", tmp, err)
-		}
-		if _, err := io.Copy(f, body); err != nil {
-			f.Close()
-			os.Remove(tmp)
-			return fmt.Errorf("failed to write to file %s: %w", tmp, err)
-		}
-		if err := f.Close(); err != nil {
-			os.Remove(tmp)
-			return fmt.Errorf("failed to close file %s: %w", tmp, err)
-		}
-		if err := os.Rename(tmp, fp); err != nil {
-			os.Remove(tmp)
-			return fmt.Errorf("failed to rename %s to %s: %w", tmp, fp, err)
-		}
-		return nil
-	}()
+		return atomicWriteFromReader(fp, body)
+	})
+}
 
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	chans := d.mu.downloads[dedupKey]
-	delete(d.mu.downloads, dedupKey)
-	for _, ch := range chans {
-		select {
-		case ch <- err:
-		default:
-		}
+// atomicWriteFromReader writes the contents of body to fp by first writing to a
+// temporary file and then atomically renaming it to fp on success.
+func atomicWriteFromReader(fp string, body io.Reader) error {
+	tmp := fp + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("failed to create file %s: %w", tmp, err)
 	}
-	return err
+	if _, err := io.Copy(f, body); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("failed to write to file %s: %w", tmp, err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("failed to close file %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, fp); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("failed to rename %s to %s: %w", tmp, fp, err)
+	}
+	return nil
 }
 
 // downloadProgressReader wraps an io.Reader and reports cumulative bytes read
@@ -373,25 +353,7 @@ func downloadFileSequential(ctx context.Context, fp, url string, onDownload OnDo
 		body = &downloadProgressReader{resp: resp, sourceURL: url, onDownload: onDownload}
 	}
 
-	tmp := fp + ".tmp"
-	f, err := os.Create(tmp)
-	if err != nil {
-		return fmt.Errorf("failed to create file %s: %w", tmp, err)
-	}
-	if _, err := io.Copy(f, body); err != nil {
-		f.Close()
-		os.Remove(tmp)
-		return fmt.Errorf("failed to write to file %s: %w", tmp, err)
-	}
-	if err := f.Close(); err != nil {
-		os.Remove(tmp)
-		return fmt.Errorf("failed to close file %s: %w", tmp, err)
-	}
-	if err := os.Rename(tmp, fp); err != nil {
-		os.Remove(tmp)
-		return fmt.Errorf("failed to rename %s to %s: %w", tmp, fp, err)
-	}
-	return nil
+	return atomicWriteFromReader(fp, body)
 }
 
 // parsedItem is an item produced by a parse worker, sent over the output

--- a/pkg/datasource/download.go
+++ b/pkg/datasource/download.go
@@ -9,7 +9,16 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"syscall"
+
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	defaultParallelDownloadThreshold = 512 << 20 // 512 MiB
+	defaultParallelDownloadChunkSize = 512 << 20 // 512 MiB
+	parallelDownloadWorkers          = 8
 )
 
 func parsingAndDownloadingIterator[T any](
@@ -133,34 +142,162 @@ func (d *downloader) downloadFile(ctx context.Context, fp, url string, onDownloa
 	}
 
 	err := func() error {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-		if err != nil {
-			return fmt.Errorf("failed to create request for %s: %w", url, err)
-		}
-
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			return fmt.Errorf("failed to download %s: %w", url, err)
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("failed to download %s: status code %d", url, resp.StatusCode)
-		}
-
 		if err := os.MkdirAll(filepath.Dir(fp), 0755); err != nil {
 			return fmt.Errorf("failed to create cache directory for %s: %w", fp, err)
 		}
+		threshold := d.cfg.ParallelDownloadThreshold
+		if threshold == 0 {
+			threshold = defaultParallelDownloadThreshold
+		}
+		chunkSize := d.cfg.ParallelDownloadChunkSize
+		if chunkSize == 0 {
+			chunkSize = defaultParallelDownloadChunkSize
+		}
+		// Issue a HEAD request first. If the server advertises Accept-Ranges:
+		// bytes and the file is large enough, download in parallel chunks.
+		size, acceptsRanges, err := headRequest(ctx, url)
+		if err == nil && acceptsRanges && size > threshold {
+			return downloadFileParallel(ctx, fp, url, size, chunkSize, onDownload)
+		}
+		return downloadFileSequential(ctx, fp, url, onDownload)
+	}()
 
-		var body io.Reader = resp.Body
-		if onDownload != nil && resp.ContentLength > 0 {
-			onDownload(url, 0, resp.ContentLength)
-			body = &downloadProgressReader{resp: resp, sourceURL: url, onDownload: onDownload}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	// Download complete, notify any waiters and remove the entry.
+	chans := d.mu.downloads[url]
+	delete(d.mu.downloads, url)
+	for _, ch := range chans {
+		select {
+		case ch <- err:
+		default:
+		}
+	}
+	return err
+}
+
+// RangeRequest is a request to download a specific byte range of a URL as its
+// own independent cache file.
+type RangeRequest struct {
+	URL   string
+	Start int64
+	End   int64 // inclusive
+}
+
+// DownloadRanged is like Download but downloads byte-range sub-requests
+// concurrently, storing each range as a separate cache file. Unlike Download,
+// it fans out to concurrency workers that issue requests in parallel.
+func (d *downloader) DownloadRanged(
+	ctx context.Context,
+	requests iter.Seq2[string, RangeRequest],
+	concurrency int,
+	hooks Hooks,
+) <-chan DownloadResult {
+	type item struct {
+		key string
+		req RangeRequest
+	}
+	reqCh := make(chan item, concurrency)
+	go func() {
+		defer close(reqCh)
+		for key, req := range requests {
+			select {
+			case reqCh <- item{key, req}:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	ch := make(chan DownloadResult, concurrency)
+	var wg sync.WaitGroup
+	for range concurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for item := range reqCh {
+				res := DownloadResult{Key: item.key, SourceURL: item.req.URL}
+				fp, err := d.maybeDownloadRangedFile(ctx, item.key, item.req, hooks)
+				if err != nil {
+					res.Err = err
+				} else {
+					res.LocalPath = fp
+				}
+				select {
+				case ch <- res:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+	return ch
+}
+
+func (d *downloader) maybeDownloadRangedFile(ctx context.Context, key string, req RangeRequest, hooks Hooks) (string, error) {
+	fp := filepath.Join(d.cfg.CacheDir, key)
+	if _, err := os.Stat(fp); err == nil {
+		if hooks.OnLoadCachedFile != nil {
+			hooks.OnLoadCachedFile(req.URL)
+		}
+		return fp, nil
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+	if err := d.downloadRangedFile(ctx, fp, req, hooks.OnDownload); err != nil {
+		return "", err
+	}
+	return fp, nil
+}
+
+func (d *downloader) downloadRangedFile(ctx context.Context, fp string, req RangeRequest, onDownload OnDownload) error {
+	// Deduplicate concurrent downloads of the same range.
+	dedupKey := fmt.Sprintf("%s#%d-%d", req.URL, req.Start, req.End)
+	if wait := func() chan error {
+		d.mu.Lock()
+		defer d.mu.Unlock()
+		if _, exists := d.mu.downloads[dedupKey]; exists {
+			ch := make(chan error)
+			d.mu.downloads[dedupKey] = append(d.mu.downloads[dedupKey], ch)
+			return ch
+		}
+		d.mu.downloads[dedupKey] = []chan error{}
+		return nil
+	}(); wait != nil {
+		return <-wait
+	}
+
+	err := func() error {
+		if err := os.MkdirAll(filepath.Dir(fp), 0755); err != nil {
+			return fmt.Errorf("failed to create cache directory for %s: %w", fp, err)
+		}
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, req.URL, nil)
+		if err != nil {
+			return fmt.Errorf("failed to create request for %s: %w", req.URL, err)
+		}
+		httpReq.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", req.Start, req.End))
+
+		resp, err := http.DefaultClient.Do(httpReq)
+		if err != nil {
+			return fmt.Errorf("failed to download %s bytes=%d-%d: %w", req.URL, req.Start, req.End, err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusPartialContent {
+			return fmt.Errorf("downloading %s bytes=%d-%d: expected 206, got %d", req.URL, req.Start, req.End, resp.StatusCode)
 		}
 
-		// Write to a temporary file and atomically rename on success,
-		// so that interrupted downloads don't leave truncated files in
-		// the cache that would be treated as valid on the next run.
+		var body io.Reader = resp.Body
+		if onDownload != nil {
+			chunkSize := req.End - req.Start + 1
+			onDownload(req.URL, 0, chunkSize)
+			body = &downloadProgressReader{resp: resp, sourceURL: req.URL, onDownload: onDownload}
+		}
+
 		tmp := fp + ".tmp"
 		f, err := os.Create(tmp)
 		if err != nil {
@@ -184,9 +321,8 @@ func (d *downloader) downloadFile(ctx context.Context, fp, url string, onDownloa
 
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	// Download complete, notify any waiters and remove the entry.
-	chans := d.mu.downloads[url]
-	delete(d.mu.downloads, url)
+	chans := d.mu.downloads[dedupKey]
+	delete(d.mu.downloads, dedupKey)
 	for _, ch := range chans {
 		select {
 		case ch <- err:
@@ -212,6 +348,183 @@ func (r *downloadProgressReader) Read(p []byte) (int, error) {
 		r.onDownload(r.sourceURL, r.received, r.resp.ContentLength)
 	}
 	return n, err
+}
+
+// headRequest issues a HEAD request and returns the content length and whether
+// the server supports byte-range requests.
+func headRequest(ctx context.Context, url string) (size int64, acceptsRanges bool, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return 0, false, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, false, err
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0, false, fmt.Errorf("HEAD %s returned status %d", url, resp.StatusCode)
+	}
+	return resp.ContentLength, resp.Header.Get("Accept-Ranges") == "bytes", nil
+}
+
+// downloadFileSequential downloads url to fp+".tmp" using a single GET request,
+// then renames the tmp file to fp on success.
+func downloadFileSequential(ctx context.Context, fp, url string, onDownload OnDownload) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request for %s: %w", url, err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download %s: status code %d", url, resp.StatusCode)
+	}
+
+	var body io.Reader = resp.Body
+	if onDownload != nil && resp.ContentLength > 0 {
+		onDownload(url, 0, resp.ContentLength)
+		body = &downloadProgressReader{resp: resp, sourceURL: url, onDownload: onDownload}
+	}
+
+	tmp := fp + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("failed to create file %s: %w", tmp, err)
+	}
+	if _, err := io.Copy(f, body); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("failed to write to file %s: %w", tmp, err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("failed to close file %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, fp); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("failed to rename %s to %s: %w", tmp, fp, err)
+	}
+	return nil
+}
+
+// downloadFileParallel downloads url to fp+".tmp" using parallel Range requests,
+// then renames the tmp file to fp on success. size must be the exact byte length
+// of the remote file as reported by the HEAD response.
+func downloadFileParallel(ctx context.Context, fp, url string, size, chunkSize int64, onDownload OnDownload) error {
+	tmp := fp + ".tmp"
+
+	f, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("failed to create %s: %w", tmp, err)
+	}
+	// Pre-allocate the full file so concurrent WriteAt calls land in bounds.
+	if err := f.Truncate(size); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("failed to pre-allocate %s: %w", tmp, err)
+	}
+
+	// Build the chunk list.
+	type chunk struct{ start, end int64 }
+	var chunks []chunk
+	for off := int64(0); off < size; off += chunkSize {
+		end := off + chunkSize - 1
+		if end >= size {
+			end = size - 1
+		}
+		chunks = append(chunks, chunk{off, end})
+	}
+
+	if onDownload != nil {
+		onDownload(url, 0, size)
+	}
+
+	var (
+		downloaded atomic.Int64
+		chunkCh    = make(chan chunk, len(chunks))
+	)
+	for _, c := range chunks {
+		chunkCh <- c
+	}
+	close(chunkCh)
+
+	g, ctx := errgroup.WithContext(ctx)
+	for range min(parallelDownloadWorkers, len(chunks)) {
+		g.Go(func() error {
+			for c := range chunkCh {
+				if err := downloadChunk(ctx, f, url, c.start, c.end, size, &downloaded, onDownload); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	f.Close()
+	if err := os.Rename(tmp, fp); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("failed to rename %s to %s: %w", tmp, fp, err)
+	}
+	return nil
+}
+
+// downloadChunk fetches bytes [start, end] of url and writes them directly into
+// f at offset start via WriteAt. Progress is reported atomically via downloaded.
+func downloadChunk(
+	ctx context.Context,
+	f *os.File,
+	url string,
+	start, end, totalSize int64,
+	downloaded *atomic.Int64,
+	onDownload OnDownload,
+) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("fetching bytes=%d-%d of %s: %w", start, end, url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusPartialContent {
+		return fmt.Errorf("fetching bytes=%d-%d of %s: expected 206, got %d", start, end, url, resp.StatusCode)
+	}
+
+	buf := make([]byte, 128<<10) // 128 KiB read buffer
+	offset := start
+	for {
+		n, err := resp.Body.Read(buf)
+		if n > 0 {
+			if _, werr := f.WriteAt(buf[:n], offset); werr != nil {
+				return fmt.Errorf("writing to %s at offset %d: %w", f.Name(), offset, werr)
+			}
+			offset += int64(n)
+			if onDownload != nil {
+				onDownload(url, downloaded.Add(int64(n)), totalSize)
+			}
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading bytes=%d-%d of %s: %w", start, end, url, err)
+		}
+	}
+	return nil
 }
 
 // parsedItem is an item produced by a parse worker, sent over the output

--- a/pkg/datasource/download.go
+++ b/pkg/datasource/download.go
@@ -9,14 +9,10 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"sync/atomic"
 	"syscall"
-
-	"golang.org/x/sync/errgroup"
 )
 
 const (
-	defaultParallelDownloadThreshold = 512 << 20 // 512 MiB
 	defaultParallelDownloadChunkSize = 512 << 20 // 512 MiB
 	parallelDownloadWorkers          = 8
 )
@@ -144,20 +140,6 @@ func (d *downloader) downloadFile(ctx context.Context, fp, url string, onDownloa
 	err := func() error {
 		if err := os.MkdirAll(filepath.Dir(fp), 0755); err != nil {
 			return fmt.Errorf("failed to create cache directory for %s: %w", fp, err)
-		}
-		threshold := d.cfg.ParallelDownloadThreshold
-		if threshold == 0 {
-			threshold = defaultParallelDownloadThreshold
-		}
-		chunkSize := d.cfg.ParallelDownloadChunkSize
-		if chunkSize == 0 {
-			chunkSize = defaultParallelDownloadChunkSize
-		}
-		// Issue a HEAD request first. If the server advertises Accept-Ranges:
-		// bytes and the file is large enough, download in parallel chunks.
-		size, acceptsRanges, err := headRequest(ctx, url)
-		if err == nil && acceptsRanges && size > threshold {
-			return downloadFileParallel(ctx, fp, url, size, chunkSize, onDownload)
 		}
 		return downloadFileSequential(ctx, fp, url, onDownload)
 	}()
@@ -408,121 +390,6 @@ func downloadFileSequential(ctx context.Context, fp, url string, onDownload OnDo
 	if err := os.Rename(tmp, fp); err != nil {
 		os.Remove(tmp)
 		return fmt.Errorf("failed to rename %s to %s: %w", tmp, fp, err)
-	}
-	return nil
-}
-
-// downloadFileParallel downloads url to fp+".tmp" using parallel Range requests,
-// then renames the tmp file to fp on success. size must be the exact byte length
-// of the remote file as reported by the HEAD response.
-func downloadFileParallel(ctx context.Context, fp, url string, size, chunkSize int64, onDownload OnDownload) error {
-	tmp := fp + ".tmp"
-
-	f, err := os.Create(tmp)
-	if err != nil {
-		return fmt.Errorf("failed to create %s: %w", tmp, err)
-	}
-	// Pre-allocate the full file so concurrent WriteAt calls land in bounds.
-	if err := f.Truncate(size); err != nil {
-		f.Close()
-		os.Remove(tmp)
-		return fmt.Errorf("failed to pre-allocate %s: %w", tmp, err)
-	}
-
-	// Build the chunk list.
-	type chunk struct{ start, end int64 }
-	var chunks []chunk
-	for off := int64(0); off < size; off += chunkSize {
-		end := off + chunkSize - 1
-		if end >= size {
-			end = size - 1
-		}
-		chunks = append(chunks, chunk{off, end})
-	}
-
-	if onDownload != nil {
-		onDownload(url, 0, size)
-	}
-
-	var (
-		downloaded atomic.Int64
-		chunkCh    = make(chan chunk, len(chunks))
-	)
-	for _, c := range chunks {
-		chunkCh <- c
-	}
-	close(chunkCh)
-
-	g, ctx := errgroup.WithContext(ctx)
-	for range min(parallelDownloadWorkers, len(chunks)) {
-		g.Go(func() error {
-			for c := range chunkCh {
-				if err := downloadChunk(ctx, f, url, c.start, c.end, size, &downloaded, onDownload); err != nil {
-					return err
-				}
-			}
-			return nil
-		})
-	}
-
-	if err := g.Wait(); err != nil {
-		f.Close()
-		os.Remove(tmp)
-		return err
-	}
-	f.Close()
-	if err := os.Rename(tmp, fp); err != nil {
-		os.Remove(tmp)
-		return fmt.Errorf("failed to rename %s to %s: %w", tmp, fp, err)
-	}
-	return nil
-}
-
-// downloadChunk fetches bytes [start, end] of url and writes them directly into
-// f at offset start via WriteAt. Progress is reported atomically via downloaded.
-func downloadChunk(
-	ctx context.Context,
-	f *os.File,
-	url string,
-	start, end, totalSize int64,
-	downloaded *atomic.Int64,
-	onDownload OnDownload,
-) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("fetching bytes=%d-%d of %s: %w", start, end, url, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusPartialContent {
-		return fmt.Errorf("fetching bytes=%d-%d of %s: expected 206, got %d", start, end, url, resp.StatusCode)
-	}
-
-	buf := make([]byte, 128<<10) // 128 KiB read buffer
-	offset := start
-	for {
-		n, err := resp.Body.Read(buf)
-		if n > 0 {
-			if _, werr := f.WriteAt(buf[:n], offset); werr != nil {
-				return fmt.Errorf("writing to %s at offset %d: %w", f.Name(), offset, werr)
-			}
-			offset += int64(n)
-			if onDownload != nil {
-				onDownload(url, downloaded.Add(int64(n)), totalSize)
-			}
-		}
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return fmt.Errorf("reading bytes=%d-%d of %s: %w", start, end, url, err)
-		}
 	}
 	return nil
 }

--- a/pkg/datasource/download.go
+++ b/pkg/datasource/download.go
@@ -327,6 +327,9 @@ func headRequest(ctx context.Context, url string) (size int64, acceptsRanges boo
 	if resp.StatusCode != http.StatusOK {
 		return 0, false, fmt.Errorf("HEAD %s returned status %d", url, resp.StatusCode)
 	}
+	if resp.ContentLength <= 0 {
+		return 0, false, fmt.Errorf("HEAD %s returned no Content-Length", url)
+	}
 	return resp.ContentLength, resp.Header.Get("Accept-Ranges") == "bytes", nil
 }
 

--- a/pkg/datasource/download_test.go
+++ b/pkg/datasource/download_test.go
@@ -68,7 +68,7 @@ func TestDownloader(t *testing.T) {
 	}
 }
 
-func TestParallelDownload(t *testing.T) {
+func TestDownloadRanged(t *testing.T) {
 	// Use a small chunk size so a small payload exercises multiple chunks and
 	// workers without downloading real data.
 	const chunkSize = 1024
@@ -82,39 +82,52 @@ func TestParallelDownload(t *testing.T) {
 	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodHead:
-			w.Header().Set("Accept-Ranges", "bytes")
-			w.Header().Set("Content-Length", strconv.Itoa(payloadSize))
-			w.WriteHeader(http.StatusOK)
-
-		case http.MethodGet:
-			// Parse "bytes=start-end".
-			var start, end int
-			fmt.Sscanf(r.Header.Get("Range"), "bytes=%d-%d", &start, &end)
-			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, payloadSize))
-			w.Header().Set("Content-Length", strconv.Itoa(end-start+1))
-			w.WriteHeader(http.StatusPartialContent)
-			w.Write(payload[start : end+1])
-		}
+		// Parse "bytes=start-end".
+		var start, end int
+		fmt.Sscanf(r.Header.Get("Range"), "bytes=%d-%d", &start, &end)
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, payloadSize))
+		w.Header().Set("Content-Length", strconv.Itoa(end-start+1))
+		w.WriteHeader(http.StatusPartialContent)
+		w.Write(payload[start : end+1])
 	}))
 	defer srv.Close()
 
 	cacheDir := t.TempDir()
-	dl := newDownloader(Config{
-		CacheDir:                  cacheDir,
-		ParallelDownloadThreshold: chunkSize,
-		ParallelDownloadChunkSize: chunkSize,
-	})
+	dl := newDownloader(Config{CacheDir: cacheDir})
 
-	fp, err := dl.maybeDownloadFile(t.Context(), "payload", srv.URL+"/payload", Hooks{})
-	if err != nil {
-		t.Fatalf("download: %v", err)
+	// Build chunk requests covering the full payload.
+	numChunks := (payloadSize + chunkSize - 1) / chunkSize
+	chunks := func(yield func(string, RangeRequest) bool) {
+		for i := range numChunks {
+			start := i * chunkSize
+			end := min(start+chunkSize-1, payloadSize-1)
+			if !yield(fmt.Sprintf("chunk-%d", i), RangeRequest{
+				URL: srv.URL + "/payload", Start: int64(start), End: int64(end),
+			}) {
+				return
+			}
+		}
 	}
 
-	got, err := os.ReadFile(fp)
-	if err != nil {
-		t.Fatalf("read: %v", err)
+	// Download all chunks and reassemble in order.
+	paths := make([]string, numChunks)
+	for res := range dl.DownloadRanged(t.Context(), chunks, 4, Hooks{}) {
+		if res.Err != nil {
+			t.Fatalf("download %s: %v", res.Key, res.Err)
+		}
+		var idx int
+		fmt.Sscanf(res.Key, "chunk-%d", &idx)
+		paths[idx] = res.LocalPath
+	}
+
+	// Concatenate chunk files and verify.
+	var got []byte
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read chunk: %v", err)
+		}
+		got = append(got, data...)
 	}
 	if !bytes.Equal(got, payload) {
 		t.Fatalf("downloaded content does not match: got %d bytes, want %d", len(got), len(payload))

--- a/pkg/datasource/download_test.go
+++ b/pkg/datasource/download_test.go
@@ -1,12 +1,15 @@
 package datasource
 
 import (
+	"bytes"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"iter"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"testing"
 )
 
@@ -62,5 +65,58 @@ func TestDownloader(t *testing.T) {
 	}
 	if count != numDocs {
 		t.Fatalf("expected %d results, got %d", numDocs, count)
+	}
+}
+
+func TestParallelDownload(t *testing.T) {
+	// Use a small chunk size so a small payload exercises multiple chunks and
+	// workers without downloading real data.
+	const chunkSize = 1024
+
+	// Build a random payload that is not an exact multiple of the chunk size
+	// so the last chunk is shorter than the rest.
+	const payloadSize = chunkSize*7 + 300
+	payload := make([]byte, payloadSize)
+	if _, err := rand.Read(payload); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Accept-Ranges", "bytes")
+			w.Header().Set("Content-Length", strconv.Itoa(payloadSize))
+			w.WriteHeader(http.StatusOK)
+
+		case http.MethodGet:
+			// Parse "bytes=start-end".
+			var start, end int
+			fmt.Sscanf(r.Header.Get("Range"), "bytes=%d-%d", &start, &end)
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, payloadSize))
+			w.Header().Set("Content-Length", strconv.Itoa(end-start+1))
+			w.WriteHeader(http.StatusPartialContent)
+			w.Write(payload[start : end+1])
+		}
+	}))
+	defer srv.Close()
+
+	cacheDir := t.TempDir()
+	dl := newDownloader(Config{
+		CacheDir:                  cacheDir,
+		ParallelDownloadThreshold: chunkSize,
+		ParallelDownloadChunkSize: chunkSize,
+	})
+
+	fp, err := dl.maybeDownloadFile(t.Context(), "payload", srv.URL+"/payload", Hooks{})
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+
+	got, err := os.ReadFile(fp)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded content does not match: got %d bytes, want %d", len(got), len(payload))
 	}
 }


### PR DESCRIPTION
Add the BigANN-Deep 1-billion vector dataset as a datasource. The vectors are stored in a single ~384 GB file, so this commit introduces logic to chunk and parallelize the file download.