### PR TITLE
datasource/download: fix silent error drop in withDedup broadcast

### DIFF
--- a/pkg/datasource/download.go
+++ b/pkg/datasource/download.go
@@ -141,10 +141,7 @@ func (d *downloader) withDedup(key string, fn func() error) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	for _, ch := range d.mu.downloads[key] {
-		select {
-		case ch <- err:
-		default:
-		}
+		ch <- err
 	}
 	delete(d.mu.downloads, key)
 	return err


### PR DESCRIPTION
The broadcast loop in `withDedup` used a non-blocking select to send
errors back to waiting goroutines:

    for _, ch := range d.mu.downloads[key] {
        select {
        case ch <- err:
        default:
        }
    }

Each waiting channel is unbuffered (`make(chan error)`). If the
scheduler preempts a waiter between registering its channel and
reaching the blocking `<-wait` receive, the broadcaster's send falls
through to `default`, silently discarding the result. The waiter then
blocks indefinitely — a goroutine leak.

Fix: remove the `default` branch so the send is blocking. This is
safe because waiters always block on `<-wait` immediately after
releasing the lock, and there is exactly one receiver per channel.

    for _, ch := range d.mu.downloads[key] {
        ch <- err
    }