### PR TITLE
bench: fix off-by-one in upsert load dispatch condition

### DIFF
--- a/pkg/bench/bench.go
+++ b/pkg/bench/bench.go
@@ -533,17 +533,17 @@ func generateUpsertLoad(ctx context.Context, n int, upsertWorkload *UpsertWorklo
 				close(upserts)
 				return
 			case <-tkr.C:
-			pendingUpserts += int(upsertWorkload.WPS)
-			for pendingUpserts >= upsertSize {
-				upserts <- UpsertLoad{
-					NamespaceIndex: indexes[nextTarget],
-					NumDocs:        upsertSize,
+					pendingUpserts += int(upsertWorkload.WPS)
+					for pendingUpserts >= upsertSize {
+						upserts <- UpsertLoad{
+							NamespaceIndex: indexes[nextTarget],
+							NumDocs:        upsertSize,
+						}
+						pendingUpserts -= upsertSize
+						nextTarget = (nextTarget + 1) % len(indexes)
+					}
 				}
-				pendingUpserts -= upsertSize
-				nextTarget = (nextTarget + 1) % len(indexes)
 			}
-		}
-		}
 	}()
 	task.Detailf("writing %d document(s) per second across all namespaces", int(upsertWorkload.WPS))
 	task.Detailf("upsert batch size: %d doc(s) per batch", upsertWorkload.UpsertBatchSize)

--- a/pkg/bench/bench.go
+++ b/pkg/bench/bench.go
@@ -533,16 +533,16 @@ func generateUpsertLoad(ctx context.Context, n int, upsertWorkload *UpsertWorklo
 				close(upserts)
 				return
 			case <-tkr.C:
-				pendingUpserts += int(upsertWorkload.WPS)
-				for pendingUpserts > upsertSize {
-					upserts <- UpsertLoad{
-						NamespaceIndex: indexes[nextTarget],
-						NumDocs:        upsertSize,
-					}
-					pendingUpserts -= upsertSize
-					nextTarget = (nextTarget + 1) % len(indexes)
+			pendingUpserts += int(upsertWorkload.WPS)
+			for pendingUpserts >= upsertSize {
+				upserts <- UpsertLoad{
+					NamespaceIndex: indexes[nextTarget],
+					NumDocs:        upsertSize,
 				}
+				pendingUpserts -= upsertSize
+				nextTarget = (nextTarget + 1) % len(indexes)
 			}
+		}
 		}
 	}()
 	task.Detailf("writing %d document(s) per second across all namespaces", int(upsertWorkload.WPS))


### PR DESCRIPTION
## What

Fix an off-by-one error in `generateUpsertLoad` where the batch
dispatch condition used strict greater-than (`>`) instead of
greater-than-or-equal (`>=`).

## Why

The accumulator loop dispatches a batch whenever `pendingUpserts`
reaches a full batch size. With `>`, batches are only sent when
`pendingUpserts` **exceeds** `upsertSize` — meaning when
`WPS == UpsertBatchSize` (e.g. both at their default of `10`),
each tick accumulates exactly `upsertSize` pending docs but the
condition is never satisfied (`10 > 10` is false). A batch only
fires after a second tick pushes it to `20`, effectively halving
write throughput silently.

Any configuration where `WPS` is an exact non-zero multiple of
`UpsertBatchSize` is affected, including the defaults.

## Fix

```diff
- for pendingUpserts > upsertSize {
+ for pendingUpserts >= upsertSize {
```

One character. No behaviour change for configurations where
`WPS` is not a multiple of `UpsertBatchSize`; correct dispatch
restored for all others.