### PR TITLE
benchmarks: add hybrid-10m-hot website nightly benchmark

### DIFF
--- a/benchmarks/website/hybrid-10m-hot.toml
+++ b/benchmarks/website/hybrid-10m-hot.toml
@@ -1,0 +1,62 @@
+name = "hybrid_10m_hot"
+namespaces = 1
+duration = "30m"
+description = """
+This benchmark evaluates hybrid search with a warm cache over 10 million
+documents. Each request is a multi-query that runs BM25 full-text search and
+1024-dimensional vector ANN against the same MSMarco query.
+
+Documents and queries are pulled from the MSMarco dataset:
+https://huggingface.co/datasets/Cohere/msmarco-v2.1-embed-english-v3
+
+After seeding the namespace, the benchmark waits for indexing to complete and
+the cache to reach a 100% hit ratio before measuring query throughput.
+"""
+
+[setup]
+wait_for_indexing = true
+warm_cache = true
+wait_for_cache_hit_ratio = 1.00
+document_count = 10_000_000
+datasource = "CohereMSMarco"
+document_template = """
+{
+    "id": {{ id }},
+    "vector": {{ vector 1024 }},
+    "text": {{ json (text) }}
+}
+"""
+upsert_template = """
+{
+    "upsert_rows": [
+        {{ .UpsertBatchPlaceholder }}
+    ],
+    "distance_metric": "cosine_distance",
+    "disable_backpressure": true,
+    "schema": {
+        "vector": {"type": "[1024]f16", "ann": true},
+        "text": {"type": "string", "full_text_search": true}
+    }
+}
+"""
+
+[workload.query.hybrid]
+qps = 8
+datasource = "CohereMSMarco"
+template = """
+{{ $q := query }}
+{
+    "queries": [
+        {
+            "top_k": 10,
+            "rank_by": ["text", "BM25", {{ json $q.Text }}]
+        },
+        {
+            "top_k": 10,
+            "rank_by": ["vector", "ANN", {{ $q.Vector 1024 }}]
+        }
+    ],
+    "rerank_by": ["RRF"],
+    "consistency": {"level": "eventual"}
+}
+"""


### PR DESCRIPTION
Track hybrid BM25+ANN search on the public nightly charts alongside the existing vector and fulltext website benchmarks.

No cold variant for now.