### PR TITLE
mark nightly = true in toml file itself

### DIFF
--- a/benchmarks/text-prefix-10m.toml
+++ b/benchmarks/text-prefix-10m.toml
@@ -1,6 +1,7 @@
 name = "text_prefix_10m"
 namespaces = 1
 duration = "5m"
+nightly = true
 description = """
 Evaluates prefix query performance on a simulated, debounced search-as-you-type workload.
 Documents and queries are pulled from the MSMARCO dataset. Queries contain up to 4 words,

--- a/benchmarks/website/fulltext-10m-cold.toml
+++ b/benchmarks/website/fulltext-10m-cold.toml
@@ -1,6 +1,7 @@
 name = "fulltext_10m_cold"
 namespaces = 1
 duration = "30m"
+nightly = true
 description = """
 This benchmark evaluates a full-text search workload with the cache disabled.
 

--- a/benchmarks/website/fulltext-10m-hot.toml
+++ b/benchmarks/website/fulltext-10m-hot.toml
@@ -1,6 +1,7 @@
 name = "fulltext_10m_hot"
 namespaces = 1
 duration = "30m"
+nightly = true
 description = """
 This benchmark evaluates a full-text search workload with a warm cache.
 

--- a/benchmarks/website/hybrid-10m-hot.toml
+++ b/benchmarks/website/hybrid-10m-hot.toml
@@ -1,6 +1,7 @@
 name = "hybrid_10m_hot"
 namespaces = 1
 duration = "30m"
+nightly = true
 description = """
 This benchmark evaluates hybrid search with a warm cache over 10 million
 documents. Each request is a multi-query that runs BM25 full-text search and

--- a/benchmarks/website/vector-10m-cold.toml
+++ b/benchmarks/website/vector-10m-cold.toml
@@ -1,6 +1,7 @@
 name = "vectors_10m_cold"
 namespaces = 1
 duration = "30m"
+nightly = true
 description = """
 This benchmark evaluates a vector search query with the cache disabled,
 returning topk=10 ANN results.

--- a/benchmarks/website/vector-10m-hot.toml
+++ b/benchmarks/website/vector-10m-hot.toml
@@ -1,6 +1,7 @@
 name = "vectors_10m_hot"
 namespaces = 1
 duration = "30m"
+nightly = true
 description = """
 This benchmark evaluates a vector search query with a warm cache, returning
 topk=10 ANN results.

--- a/cmd/tpufbench/main.go
+++ b/cmd/tpufbench/main.go
@@ -4,11 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"log"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -75,6 +80,22 @@ func main() {
 		}
 		addExecutionFlags(runCmd.Flags(), &cfg)
 		return runCmd
+	}())
+
+	// list command
+	rootCmd.AddCommand(func() *cobra.Command {
+		var nightlyOnly bool
+		listCmd := &cobra.Command{
+			Use:   "list <dir>...",
+			Short: "List benchmark definition files found under the given directories",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return list(cmd.OutOrStdout(), args, nightlyOnly)
+			},
+			Args: cobra.MinimumNArgs(1),
+		}
+		listCmd.Flags().BoolVar(&nightlyOnly, "nightly", false,
+			"only list benchmarks marked with 'nightly = true'")
+		return listCmd
 	}())
 
 	if err := rootCmd.Execute(); err != nil {
@@ -149,6 +170,43 @@ func run(ctx context.Context, serviceCfg bench.ServiceConfig, cfg bench.RuntimeC
 
 	if err = bench.Run(ctx, &client, def, cfg, logger); err != nil {
 		return err
+	}
+	return nil
+}
+
+// list walks the given directories for benchmark definition files (*.toml),
+// parses each one, and writes the path of every match to w (one per line).
+// When nightlyOnly is set, only definitions with 'nightly = true' are listed.
+// Paths are sorted for deterministic output.
+func list(w io.Writer, dirs []string, nightlyOnly bool) error {
+	var paths []string
+	for _, dir := range dirs {
+		err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(path, ".toml") {
+				return nil
+			}
+			def, err := bench.ParseDefinition(path)
+			if err != nil {
+				return fmt.Errorf("parsing %s: %w", path, err)
+			}
+			if nightlyOnly && !def.Nightly {
+				return nil
+			}
+			paths = append(paths, path)
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	sort.Strings(paths)
+	for _, p := range paths {
+		if _, err := fmt.Fprintln(w, p); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/bench/definition.go
+++ b/pkg/bench/definition.go
@@ -35,9 +35,11 @@ func ParseDefinition(path string) (*Definition, error) {
 
 // Definition defines a benchmark, including the workload and configuration.
 type Definition struct {
-	Name        string          `toml:"name"`
-	Duration    time.Duration   `toml:"duration,omitempty"`
-	Namespaces  int             `toml:"namespaces"`
+	Name       string        `toml:"name"`
+	Duration   time.Duration `toml:"duration,omitempty"`
+	Namespaces int           `toml:"namespaces"`
+	// Nightly indicates the benchmark should run as part of the nightly suite.
+	Nightly     bool            `toml:"nightly,omitempty"`
 	Description string          `toml:"description,omitempty"`
 	Setup       SetupDefinition `toml:"setup"`
 	Workloads   Workloads       `toml:"workload"`

--- a/scripts/run-remote.sh
+++ b/scripts/run-remote.sh
@@ -36,8 +36,13 @@ fi
 $SCP tpufbench $NODE_NAME:~/
 $SCP --recurse benchmarks $NODE_NAME:~/
 
-# Run each benchmark on the remote instance.
-BENCHMARKS=$(find benchmarks/website -name '*.toml')
+# Run each benchmark on the remote instance. The set of nightly benchmarks is
+# determined by the binary (definitions marked `nightly = true`); run via SSH
+# since the uploaded binary is built for the remote's architecture.
+#
+# TODO: Move the loop below into the binary (e.g. `tpufbench run-suite
+# --nightly`) so this script is just instance lifecycle + scp.
+BENCHMARKS=$($SSH ./tpufbench list --nightly benchmarks)
 $SSH rm -rf results
 $SSH mkdir -p results
 for f in $BENCHMARKS; do


### PR DESCRIPTION
Previously, nightly benchmarks would run only in the website/ folder. I wanted to expand this for non-website benchmarks, e.g. not be dependent on any given folder structure. Now, benchmarks that define `nightly: true` will be run nightly.

Also, starts pushing us in the direction of orchestrating more of the nightly benchmarks from Go itself, which feels right