### PR TITLE
benchmarks: quote uuid in text-prefix-10m document template

### DIFF
--- a/benchmarks/text-prefix-10m.toml
+++ b/benchmarks/text-prefix-10m.toml
@@ -19,7 +19,7 @@ document_count = 10_000_000
 datasource = "CohereMSMarco"
 document_template = """
 {
-    "id": {{ uuid }},
+    "id": "{{ uuid }}",
     "text": {{ json (text) }}
 }
 """


### PR DESCRIPTION
The document template used `"id": {{ uuid }}`, but the `uuid` template function returns a bare string, so the rendered document contained an unquoted UUID and was invalid JSON. Quoting the placeholder fixes the rendered output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)