### PR TITLE
Add environment fallbacks for run flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-tpufbench
+/tpufbench
 dev.sh
 .DS_Store
 results/

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ go build -o tpufbench ./cmd/tpufbench
 Then, you can run an example benchmark:
 
 ```bash
-TURBOPUFFER_API_KEY=tpuf_myapikey TURBOPUFFER_REGION=gcp-us-central1 ./tpufbench run \
+TURBOPUFFER_API_KEY=tpuf_myapikey TPUFBENCH_ENDPOINT=https://gcp-us-central1.turbopuffer.com ./tpufbench run \
     --warm-cache \
     ./benchmarks/website/vector-1m.toml
 ```
@@ -34,6 +34,26 @@ To see a list of all available configuration options, run:
 ./tpufbench run --help
 ```
 
+### Environment variable configuration
+
+Most `tpufbench run` flags can also be configured with environment variables. Explicit command-line flags take precedence over environment variables, and environment variables take precedence over the built-in defaults.
+
+| Flag | Environment variable |
+| --- | --- |
+| `--endpoint` | `TPUFBENCH_ENDPOINT` |
+| `--host-header` | `TPUFBENCH_HOST_HEADER` |
+| `--allow-tls-insecure` | `TPUFBENCH_ALLOW_TLS_INSECURE` |
+| `--namespace-prefix` | `TPUFBENCH_NAMESPACE_PREFIX` |
+| `--namespace-setup-concurrency` | `TPUFBENCH_NAMESPACE_SETUP_CONCURRENCY` |
+| `--namespace-setup-concurrency-max` | `TPUFBENCH_NAMESPACE_SETUP_CONCURRENCY_MAX` |
+| `--if-nonempty` | `TPUFBENCH_IF_NONEMPTY` |
+| `--output-dir` | `TPUFBENCH_OUTPUT_DIR` |
+| `--warm-cache` | `TPUFBENCH_WARM_CACHE` |
+| `--purge-cache` | `TPUFBENCH_PURGE_CACHE` |
+| `--duration` | `TPUFBENCH_DURATION` |
+
+`TURBOPUFFER_API_KEY` is still required for API authentication. `DATASET_CACHE_DIR` can be used to choose the local dataset cache directory.
+
 ### Reproducing website benchmarks
 
 All benchmarks were run on a c2-standard-30 instance running in GCP
@@ -41,7 +61,7 @@ us-central1. The files definining the benchmarks and their parameters are in
 `benchmarks/website`.
 
 ```bash
-TURBOPUFFER_API_KEY=tpuf_myapikey TURBOPUFFER_REGION=gcp-us-central1 ./tpufbench run \
+TURBOPUFFER_API_KEY=tpuf_myapikey TPUFBENCH_ENDPOINT=https://gcp-us-central1.turbopuffer.com ./tpufbench run \
     --warm-cache \
     ./benchmarks/website/vector-1m.toml
 ```

--- a/cmd/tpufbench/main.go
+++ b/cmd/tpufbench/main.go
@@ -25,6 +25,26 @@ import (
 	"github.com/turbopuffer/turbopuffer-go"
 )
 
+// Environment variables that can be used as fallbacks for run flags.
+const (
+	envEndpoint                     = "TPUFBENCH_ENDPOINT"
+	envHostHeader                   = "TPUFBENCH_HOST_HEADER"
+	envAllowTLSInsecure             = "TPUFBENCH_ALLOW_TLS_INSECURE"
+	envNamespacePrefix              = "TPUFBENCH_NAMESPACE_PREFIX"
+	envNamespaceSetupConcurrency    = "TPUFBENCH_NAMESPACE_SETUP_CONCURRENCY"
+	envNamespaceSetupConcurrencyMax = "TPUFBENCH_NAMESPACE_SETUP_CONCURRENCY_MAX"
+	envIfNonempty                   = "TPUFBENCH_IF_NONEMPTY"
+	envOutputDir                    = "TPUFBENCH_OUTPUT_DIR"
+	envWarmCache                    = "TPUFBENCH_WARM_CACHE"
+	envPurgeCache                   = "TPUFBENCH_PURGE_CACHE"
+	envDuration                     = "TPUFBENCH_DURATION"
+)
+
+// envHelp appends the environment variable name to a flag description.
+func envHelp(description, envName string) string {
+	return fmt.Sprintf("%s (env: %s)", description, envName)
+}
+
 func main() {
 	rootCmd := &cobra.Command{
 		Use:   "tpufbench",
@@ -35,29 +55,29 @@ func main() {
 		APIKey: os.Getenv("TURBOPUFFER_API_KEY"),
 	}
 	rootCmd.PersistentFlags().StringVar(&serviceCfg.Endpoint,
-		"endpoint", "https://REGION.turbopuffer.com", "the turbopuffer endpoint to use")
+		"endpoint", "https://REGION.turbopuffer.com", envHelp("the turbopuffer endpoint to use", envEndpoint))
 	rootCmd.PersistentFlags().StringVar(&serviceCfg.HostHeader,
-		"host-header", "", "an optional host header to include with turbopuffer requests")
+		"host-header", "", envHelp("an optional host header to include with turbopuffer requests", envHostHeader))
 	rootCmd.PersistentFlags().BoolVar(&serviceCfg.AllowTLSInsecure,
-		"allow-tls-insecure", false, "allow insecure TLS connections to the turbopuffer API")
+		"allow-tls-insecure", false, envHelp("allow insecure TLS connections to the turbopuffer API", envAllowTLSInsecure))
 
 	addExecutionFlags := func(flags *pflag.FlagSet, cfg *bench.RuntimeConfig) {
 		flags.StringVar(&cfg.NamespacePrefix, "namespace-prefix", "",
-			"a unique string to prefix namespace names with. If unset, defaults to your machine hostname and the definition name")
+			envHelp("a unique string to prefix namespace names with. If unset, defaults to your machine hostname and the definition name", envNamespacePrefix))
 		flags.IntVar(&cfg.NamespaceSetupConcurrency, "namespace-setup-concurrency", 4,
-			"the maximum number of concurrent requests per namespace when upserting documents to setup a namespace")
+			envHelp("the maximum number of concurrent requests per namespace when upserting documents to setup a namespace", envNamespaceSetupConcurrency))
 		flags.IntVar(&cfg.NamespaceSetupConcurrencyMax, "namespace-setup-concurrency-max", 64,
-			"maximum number of concurrent requests when upserting documetnts to setup namespaces (across all namespaces)")
+			envHelp("maximum number of concurrent requests when upserting documetnts to setup namespaces (across all namespaces)", envNamespaceSetupConcurrencyMax))
 		flags.StringVar(&cfg.IfNonempty, "if-nonempty", "abort",
-			"behavior when namespaces already contain data: 'clear' to delete existing data, 'skip-upsert' to use as-is, 'abort' to stop with an error")
+			envHelp("behavior when namespaces already contain data: 'clear' to delete existing data, 'skip-upsert' to use as-is, 'abort' to stop with an error", envIfNonempty))
 		flags.StringVar(&cfg.OutputDir, "output-dir", "",
-			"directory to write benchmark results to. if empty, creates a new directory in results/")
+			envHelp("directory to write benchmark results to. if empty, creates a new directory in results/", envOutputDir))
 		flags.BoolVar(&cfg.WarmCache, "warm-cache", false,
-			"warm the cache of all namespaces before starting the benchmark")
+			envHelp("warm the cache of all namespaces before starting the benchmark", envWarmCache))
 		flags.BoolVar(&cfg.PurgeCache, "purge-cache", false,
-			"purge the cache of all namespaces before starting the benchmark")
+			envHelp("purge the cache of all namespaces before starting the benchmark", envPurgeCache))
 		flags.DurationVar(&cfg.Duration, "duration", 0,
-			"override the benchmark duration (e.g. '5m', '1h'). if unset, uses the definition's duration")
+			envHelp("override the benchmark duration (e.g. '5m', '1h'). if unset, uses the definition's duration", envDuration))
 	}
 
 	// run command
@@ -67,6 +87,10 @@ func main() {
 			Use:   "run <definition-path>",
 			Short: "Run an individual turbopuffer benchmark",
 			RunE: func(cmd *cobra.Command, args []string) error {
+				if err := applyEnvFallbacks(runEnvFallbacks, cmd.Flags(), cmd.InheritedFlags()); err != nil {
+					return err
+				}
+
 				rctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 				defer cancel()
 				logger := output.NewLogger(cmd.OutOrStdout())
@@ -101,6 +125,61 @@ func main() {
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
+}
+
+// envFallback maps a flag to the environment variable that can configure it.
+type envFallback struct {
+	FlagName string
+	EnvName  string
+}
+
+// runEnvFallbacks lists the environment fallbacks supported by tpufbench run.
+var runEnvFallbacks = []envFallback{
+	{FlagName: "endpoint", EnvName: envEndpoint},
+	{FlagName: "host-header", EnvName: envHostHeader},
+	{FlagName: "allow-tls-insecure", EnvName: envAllowTLSInsecure},
+	{FlagName: "namespace-prefix", EnvName: envNamespacePrefix},
+	{FlagName: "namespace-setup-concurrency", EnvName: envNamespaceSetupConcurrency},
+	{FlagName: "namespace-setup-concurrency-max", EnvName: envNamespaceSetupConcurrencyMax},
+	{FlagName: "if-nonempty", EnvName: envIfNonempty},
+	{FlagName: "output-dir", EnvName: envOutputDir},
+	{FlagName: "warm-cache", EnvName: envWarmCache},
+	{FlagName: "purge-cache", EnvName: envPurgeCache},
+	{FlagName: "duration", EnvName: envDuration},
+}
+
+// applyEnvFallbacks applies env values for flags that were not set explicitly.
+func applyEnvFallbacks(fallbacks []envFallback, flagSets ...*pflag.FlagSet) error {
+	for _, fallback := range fallbacks {
+		flag := lookupFlag(fallback.FlagName, flagSets...)
+		if flag == nil {
+			return fmt.Errorf("flag %q not found for environment fallback %s", fallback.FlagName, fallback.EnvName)
+		}
+		if flag.Changed {
+			continue
+		}
+		value, ok := os.LookupEnv(fallback.EnvName)
+		if !ok || value == "" {
+			continue
+		}
+		if err := flag.Value.Set(value); err != nil {
+			return fmt.Errorf("invalid %s=%q for --%s: %w", fallback.EnvName, value, fallback.FlagName, err)
+		}
+	}
+	return nil
+}
+
+// lookupFlag finds a flag by name across multiple flag sets.
+func lookupFlag(name string, flagSets ...*pflag.FlagSet) *pflag.Flag {
+	for _, flags := range flagSets {
+		if flags == nil {
+			continue
+		}
+		if flag := flags.Lookup(name); flag != nil {
+			return flag
+		}
+	}
+	return nil
 }
 
 func run(ctx context.Context, serviceCfg bench.ServiceConfig, cfg bench.RuntimeConfig, logger *output.Logger, definitionPath string) error {

--- a/cmd/tpufbench/main_test.go
+++ b/cmd/tpufbench/main_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+)
+
+func newEnvFallbackTestFlagSet(t *testing.T, args ...string) *pflag.FlagSet {
+	t.Helper()
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.Int("workers", 1, "")
+	flags.Bool("verbose", false, "")
+	flags.Duration("timeout", time.Second, "")
+	flags.String("name", "default", "")
+
+	if err := flags.Parse(args); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	return flags
+}
+
+func TestApplyEnvFallbacksExplicitFlagWinsOverEnv(t *testing.T) {
+	t.Setenv("TPUF_TEST_WORKERS", "99")
+
+	flags := newEnvFallbackTestFlagSet(t, "--workers=7")
+	err := applyEnvFallbacks([]envFallback{{FlagName: "workers", EnvName: "TPUF_TEST_WORKERS"}}, flags)
+	if err != nil {
+		t.Fatalf("applyEnvFallbacks: %v", err)
+	}
+
+	got, err := flags.GetInt("workers")
+	if err != nil {
+		t.Fatalf("GetInt: %v", err)
+	}
+	if got != 7 {
+		t.Fatalf("workers = %d, want explicit flag value 7", got)
+	}
+}
+
+func TestApplyEnvFallbacksEnvAppliesWhenFlagAbsent(t *testing.T) {
+	t.Setenv("TPUF_TEST_WORKERS", "42")
+
+	flags := newEnvFallbackTestFlagSet(t)
+	err := applyEnvFallbacks([]envFallback{{FlagName: "workers", EnvName: "TPUF_TEST_WORKERS"}}, flags)
+	if err != nil {
+		t.Fatalf("applyEnvFallbacks: %v", err)
+	}
+
+	got, err := flags.GetInt("workers")
+	if err != nil {
+		t.Fatalf("GetInt: %v", err)
+	}
+	if got != 42 {
+		t.Fatalf("workers = %d, want env value 42", got)
+	}
+}
+
+func TestApplyEnvFallbacksEmptyEnvIgnored(t *testing.T) {
+	t.Setenv("TPUF_TEST_NAME", "")
+
+	flags := newEnvFallbackTestFlagSet(t)
+	err := applyEnvFallbacks([]envFallback{{FlagName: "name", EnvName: "TPUF_TEST_NAME"}}, flags)
+	if err != nil {
+		t.Fatalf("applyEnvFallbacks: %v", err)
+	}
+
+	got, err := flags.GetString("name")
+	if err != nil {
+		t.Fatalf("GetString: %v", err)
+	}
+	if got != "default" {
+		t.Fatalf("name = %q, want default", got)
+	}
+}
+
+func TestApplyEnvFallbacksInvalidEnvValuesReturnErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		flagName string
+		envName  string
+		envValue string
+	}{
+		{
+			name:     "invalid int",
+			flagName: "workers",
+			envName:  "TPUF_TEST_WORKERS",
+			envValue: "not-an-int",
+		},
+		{
+			name:     "invalid bool",
+			flagName: "verbose",
+			envName:  "TPUF_TEST_VERBOSE",
+			envValue: "not-a-bool",
+		},
+		{
+			name:     "invalid duration",
+			flagName: "timeout",
+			envName:  "TPUF_TEST_TIMEOUT",
+			envValue: "not-a-duration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(tt.envName, tt.envValue)
+
+			flags := newEnvFallbackTestFlagSet(t)
+			err := applyEnvFallbacks([]envFallback{{FlagName: tt.flagName, EnvName: tt.envName}}, flags)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.envName) {
+				t.Fatalf("error %q does not mention env var %s", err, tt.envName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What?

Add environment variable fallbacks for `tpufbench run` flags, preserving explicit CLI flag precedence.

Supported env vars:

- `TPUFBENCH_ENDPOINT`
- `TPUFBENCH_HOST_HEADER`
- `TPUFBENCH_ALLOW_TLS_INSECURE`
- `TPUFBENCH_NAMESPACE_PREFIX`
- `TPUFBENCH_NAMESPACE_SETUP_CONCURRENCY`
- `TPUFBENCH_NAMESPACE_SETUP_CONCURRENCY_MAX`
- `TPUFBENCH_IF_NONEMPTY`
- `TPUFBENCH_OUTPUT_DIR`
- `TPUFBENCH_WARM_CACHE`
- `TPUFBENCH_PURGE_CACHE`
- `TPUFBENCH_DURATION`

This also documents the env vars in README and updates examples to use `TPUFBENCH_ENDPOINT`.

## Why?

This makes it easier to ship `tpufbench` as a Kubernetes CronJob and configure runs dynamically via ConfigMaps or environment injection.

## Behavior

Precedence is:

```text
explicit CLI flag > environment variable > built-in default
```

Empty env vars are ignored.

## Verification

```bash
gofmt -w cmd/tpufbench/main.go cmd/tpufbench/main_test.go
go test -count=1 ./...
go build -v ./...
go run ./cmd/tpufbench run --help
```
