### PR TITLE
benchmarks: add exact vector search benchmarks

### DIFF
--- a/benchmarks/vector-knn-1m-cold.toml
+++ b/benchmarks/vector-knn-1m-cold.toml
@@ -1,0 +1,46 @@
+name = "vectors_knn_1m_cold"
+namespaces = 1
+duration = "5m"
+nightly = true
+description = """
+This benchmark evaluates an exact vector search query with the cache disabled,
+returning topk=10 kNN results.
+
+Embeddings have 1024 dimensions and are pulled from the Cohere Wikipedia
+dataset:
+https://huggingface.co/datasets/Cohere/wikipedia-2023-11-embed-multilingual-v3
+
+When generating queries, the query vectors are pseudorandomly generated.
+"""
+
+[setup]
+wait_for_indexing = true
+document_count = 1_000_000
+datasource = "CohereWikipediaEmbeddings"
+document_template = """
+{
+    "id": {{ id }},
+    "vector": {{ vector 1024 }}
+}
+"""
+upsert_template = """
+{
+    "upsert_rows": [
+        {{ .UpsertBatchPlaceholder }}
+    ],
+    "distance_metric": "cosine_distance",
+    "disable_backpressure": true
+}
+"""
+
+[workload.query.knn]
+qps = 1
+datasource = "random"
+template = """
+{
+    "top_k": 10,
+    "rank_by": ["vector", "kNN", {{ vector 1024 }}],
+    "filters": ["id", "Gte", 0],
+    "disable_cache": true
+}
+"""

--- a/benchmarks/vector-knn-1m-hot-multi.toml
+++ b/benchmarks/vector-knn-1m-hot-multi.toml
@@ -1,0 +1,56 @@
+name = "vectors_knn_1m_hot_multi"
+namespaces = 1
+duration = "5m"
+nightly = false
+description = """
+This benchmark evaluates an exact vector search multi-query with a warm cache,
+returning topk=10 kNN results. Each query performs 8 concurrent vector
+searches and thus benefits from bulk optimizations.
+
+Embeddings have 1024 dimensions and are pulled from the Cohere Wikipedia
+dataset:
+https://huggingface.co/datasets/Cohere/wikipedia-2023-11-embed-multilingual-v3
+
+When generating queries, the query vectors are pseudorandomly generated.
+"""
+
+[setup]
+wait_for_indexing = true
+warm_cache = true
+wait_for_cache_hit_ratio = 1.00
+document_count = 1_000_000
+datasource = "CohereWikipediaEmbeddings"
+document_template = """
+{
+    "id": {{ id }},
+    "vector": {{ vector 1024 }}
+}
+"""
+upsert_template = """
+{
+    "upsert_rows": [
+        {{ .UpsertBatchPlaceholder }}
+    ],
+    "distance_metric": "cosine_distance",
+    "disable_backpressure": true
+}
+"""
+
+[workload.query.knn]
+qps = 1
+concurrency = 1
+datasource = "random"
+template = """
+{
+    "queries": [
+        {{- range $i, $_ := N 8 -}}
+        {{- if $i }},{{ end }}
+        {
+            "top_k": 10,
+            "rank_by": ["vector", "kNN", {{ vector 1024 }}],
+            "filters": ["id", "Gte", 0]
+        }
+        {{- end }}
+    ]
+}
+"""

--- a/benchmarks/vector-knn-1m-hot.toml
+++ b/benchmarks/vector-knn-1m-hot.toml
@@ -1,0 +1,47 @@
+name = "vectors_knn_1m_hot"
+namespaces = 1
+duration = "5m"
+nightly = true
+description = """
+This benchmark evaluates an exact vector search query with a warm cache,
+returning topk=10 kNN results.
+
+Embeddings have 1024 dimensions and are pulled from the Cohere Wikipedia
+dataset:
+https://huggingface.co/datasets/Cohere/wikipedia-2023-11-embed-multilingual-v3
+
+When generating queries, the query vectors are pseudorandomly generated.
+"""
+
+[setup]
+wait_for_indexing = true
+warm_cache = true
+wait_for_cache_hit_ratio = 1.00
+document_count = 1_000_000
+datasource = "CohereWikipediaEmbeddings"
+document_template = """
+{
+    "id": {{ id }},
+    "vector": {{ vector 1024 }}
+}
+"""
+upsert_template = """
+{
+    "upsert_rows": [
+        {{ .UpsertBatchPlaceholder }}
+    ],
+    "distance_metric": "cosine_distance",
+    "disable_backpressure": true
+}
+"""
+
+[workload.query.knn]
+qps = 1
+datasource = "random"
+template = """
+{
+    "top_k": 10,
+    "rank_by": ["vector", "kNN", {{ vector 1024 }}],
+    "filters": ["id", "Gte", 0]
+}
+"""


### PR DESCRIPTION
This adds three new benchmarks, all exercising exact vector search ("kNN"):

* 1m documents, cold cache
* 1m documents, hot cache
* 1m documents, hot cache, in batches of 8 queries

The latter benchmark is meant to exercise the kNN bulk optimization, once it lands.

The non-batch benchmarks are added to the nightly schedule, so we can monitor kNN performance over time.

## Current results

* `vector-knn-1m-cold.toml`

```
combined:
   count: 292
   throughput: 1.0 queries/sec
   latencies: min=6243ms, p50=7153ms, p90=7846ms, p99=8700ms, p99.9=8863ms, max=8863ms
```

* `vector-knn-1m-hot.toml`

```
combined:
   count: 296
   throughput: 1.0 queries/sec
   latencies: min=1987ms, p50=2079ms, p90=2777ms, p99=8458ms, p99.9=10927ms, max=10927ms
```

* `vector-knn-1m-hot-multi.toml`

```
combined:
   count: 122
   throughput: 0.4 queries/sec
   latencies: min=2258ms, p50=2380ms, p90=2520ms, p99=4354ms, p99.9=7065ms, max=7065ms
```