### PR TITLE
run-remote: clean existing benchmark configs

### DIFF
--- a/scripts/run-remote.sh
+++ b/scripts/run-remote.sh
@@ -34,6 +34,7 @@ fi
 
 # Upload the binary and benchmark configs.
 $SCP tpufbench $NODE_NAME:~/
+$SSH rm -rf benchmarks
 $SCP --recurse benchmarks $NODE_NAME:~/
 
 # Run each benchmark on the remote instance. The set of nightly benchmarks is


### PR DESCRIPTION
Before uploading the current benchmark configs, remove any configs already existing on the remote. This is to prevent unintentionally running benchmarks uploaded by a different job, which is likely to cause timeouts.