### PR TITLE
Add Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`tpuf-benchmark` (binary `tpufbench`) is a single-product Go CLI that benchmarks a
+remote [turbopuffer](https://turbopuffer.com) deployment (vector/FTS/hybrid search
+and upserts). It hosts no local server or database; the only backing "service" is
+the external turbopuffer API reached over HTTPS. There is no monorepo, no Docker,
+and no JS/Python toolchain required for the core tool (`generate_charts.py` is an
+optional Python post-processing script for results).
+
+Standard commands live in `README.md` and the `Makefile`. Quick reference:
+- Lint: `go vet ./...`
+- Test: `go test ./...` (offline; covers definition parsing and datasource logic)
+- Build: `make build` (`go build -o tpufbench ./cmd/tpufbench`)
+- List benchmarks (offline): `./tpufbench list benchmarks/`
+
+Non-obvious notes:
+- A real benchmark run requires a valid `TURBOPUFFER_API_KEY` env var plus an
+  `--endpoint` (e.g. `--endpoint https://gcp-us-central1.turbopuffer.com`). The
+  default endpoint `https://REGION.turbopuffer.com` is a placeholder and will not
+  resolve. Without a valid key, `tpufbench run` fails early in its API sanity
+  check with a `401 Unauthorized` (this is expected, not an env problem).
+- `tpufbench run` starts an in-process debug/metrics server on `:6060`
+  (`/metrics`, `/debug/pprof/`) only while a benchmark is running.
+- The committed definitions under `benchmarks/` are large (1M–1B documents) and
+  are meant to run for minutes from a cloud VM in the turbopuffer region. For a
+  fast smoke test, write a small TOML using `datasource = "random"` with a tiny
+  `document_count` and a short `duration`, then run it against a real endpoint.
+- Datasets are cached to disk at `DATASET_CACHE_DIR` (defaults to the OS temp
+  dir). Only the `random` datasource avoids network dataset downloads.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Documents how to build, test, lint, and run `tpufbench` in the Cursor Cloud environment so future agents know the tool is a client-side CLI that requires a valid `TURBOPUFFER_API_KEY` and real `--endpoint` for end-to-end benchmark runs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4a5c406-189c-4b34-9871-da29a497b6d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4a5c406-189c-4b34-9871-da29a497b6d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

