### PR TITLE
benchmarks: add tpc-h q1 and an sf1 lineitem dataset

### DIFF
--- a/benchmarks/tpch-sf1.toml
+++ b/benchmarks/tpch-sf1.toml
@@ -1,0 +1,135 @@
+name = "tpch_sf1"
+namespaces = 1
+duration = "10m"
+description = """
+TPC-H scale factor 1, writing only the lineitem table (6,000,000 rows).
+
+Each document includes the standard lineitem attributes plus non-spec
+computed attributes so TPC-H aggregations can be expressed against turbopuffer:
+
+- l_disc_price = l_extendedprice * (1 - l_discount) (query 1)
+- l_charge = l_extendedprice * (1 - l_discount) * (1 + l_tax) (query 1)
+- l_revenue = l_extendedprice * l_discount (query 6)
+"""
+
+[setup]
+wait_for_indexing = true
+warm_cache = true
+wait_for_cache_hit_ratio = 1.00
+document_count = 6_000_000
+datasource = "TPCHLineitemSF1"
+document_template = """
+{{ $l := lineitem }}
+{
+    "id": {{ $l.ID }},
+    "l_orderkey": {{ $l.OrderKey }},
+    "l_partkey": {{ $l.PartKey }},
+    "l_suppkey": {{ $l.SuppKey }},
+    "l_linenumber": {{ $l.LineNumber }},
+    "l_quantity": {{ $l.Quantity }},
+    "l_extendedprice": {{ $l.ExtendedPrice }},
+    "l_discount": {{ $l.Discount }},
+    "l_tax": {{ $l.Tax }},
+    "l_returnflag": {{ json $l.ReturnFlag }},
+    "l_linestatus": {{ json $l.LineStatus }},
+    "l_shipdate": {{ json $l.ShipDate }},
+    "l_commitdate": {{ json $l.CommitDate }},
+    "l_receiptdate": {{ json $l.ReceiptDate }},
+    "l_shipinstruct": {{ json $l.ShipInstruct }},
+    "l_shipmode": {{ json $l.ShipMode }},
+    "l_comment": {{ json $l.Comment }},
+    "l_disc_price": {{ $l.DiscPrice }},
+    "l_charge": {{ $l.Charge }}
+    "l_revenue": {{ $l.Revenue }},
+}
+"""
+upsert_template = """
+{
+    "upsert_rows": [
+        {{ .UpsertBatchPlaceholder }}
+    ],
+    "disable_backpressure": true,
+    "schema": {
+        "l_orderkey": "int",
+        "l_partkey": "int",
+        "l_suppkey": "int",
+        "l_linenumber": {
+            "type": "int",
+            "filterable": false
+        },
+        "l_quantity": "int",
+        "l_extendedprice": {
+            "type": "float",
+            "filterable": false
+        },
+        "l_discount": "float",
+        "l_tax": {
+            "type": "float",
+            "filterable": false
+        },
+        "l_returnflag": "string",
+        "l_linestatus": "string",
+        "l_shipdate": "datetime",
+        "l_commitdate": "datetime",
+        "l_receiptdate": "datetime",
+        "l_shipinstruct": "string",
+        "l_shipmode": "string",
+        "l_comment": {
+            "type": "string",
+            "filterable": false
+        },
+        "l_disc_price": {
+            "type": "float",
+            "filterable": false
+        },
+        "l_charge": {
+            "type": "float",
+            "filterable": false
+        }
+        "l_revenue": {
+            "type": "float",
+            "filterable": false
+        },
+    }
+}
+"""
+
+[workload.query.q1]
+qps = 1
+concurrency = 1
+datasource = "TPCHLineitemSF1"
+template = """
+{
+    "aggregate_by": {
+        "sum_qty":        ["Sum", "l_quantity"],
+        "sum_base_price": ["Sum", "l_extendedprice"],
+        "sum_disc_price": ["Sum", "l_disc_price"],
+        "sum_charge":     ["Sum", "l_charge"],
+        "avg_qty":        ["Avg", "l_quantity"],
+        "avg_price":      ["Avg", "l_extendedprice"],
+        "avg_disc":       ["Avg", "l_discount"],
+        "count_order":    ["Count"]
+    },
+    "group_by": ["l_returnflag", "l_linestatus"],
+    "filters": ["l_shipdate", "Lte", "1998-09-02T00:00:00Z"]
+}
+"""
+
+[workload.query.q6]
+qps = 1
+concurrency = 1
+datasource = "TPCHLineitemSF1"
+template = """
+{
+    "aggregate_by": {
+        "revenue": ["Sum", "l_revenue"]
+    },
+    "filters": ["And", [
+        ["l_shipdate", "Gte", "1994-01-01T00:00:00Z"],
+        ["l_shipdate", "Lt", "1995-01-01T00:00:00Z"],
+        ["l_discount", "Gte", 0.05],
+        ["l_discount", "Lte", 0.07],
+        ["l_quantity", "Lt", 24]
+    ]]
+}
+"""

--- a/benchmarks/tpch-sf1.toml
+++ b/benchmarks/tpch-sf1.toml
@@ -39,8 +39,8 @@ document_template = """
     "l_shipmode": {{ json $l.ShipMode }},
     "l_comment": {{ json $l.Comment }},
     "l_disc_price": {{ $l.DiscPrice }},
-    "l_charge": {{ $l.Charge }}
-    "l_revenue": {{ $l.Revenue }},
+    "l_charge": {{ $l.Charge }},
+    "l_revenue": {{ $l.Revenue }}
 }
 """
 upsert_template = """
@@ -85,11 +85,11 @@ upsert_template = """
         "l_charge": {
             "type": "float",
             "filterable": false
-        }
+        },
         "l_revenue": {
             "type": "float",
             "filterable": false
-        },
+        }
     }
 }
 """

--- a/benchmarks/tpch-sf10.toml
+++ b/benchmarks/tpch-sf10.toml
@@ -1,12 +1,15 @@
-name = "tpch_sf10_q6"
+name = "tpch_sf10"
 namespaces = 1
 duration = "10m"
 description = """
 TPC-H scale factor 10, writing only the lineitem table (59,986,052 rows).
 
-Each document includes the standard lineitem attributes plus a non-spec
-l_revenue = l_extendedprice * l_discount attribute so TPC-H query 6 can be
-expressed as a filtered Sum aggregation against turbopuffer.
+Each document includes the standard lineitem attributes plus non-spec
+computed attributes so TPC-H aggregations can be expressed against turbopuffer:
+
+- l_disc_price = l_extendedprice * (1 - l_discount) (query 1)
+- l_charge = l_extendedprice * (1 - l_discount) * (1 + l_tax) (query 1)
+- l_revenue = l_extendedprice * l_discount (query 6)
 """
 
 [setup]
@@ -35,7 +38,9 @@ document_template = """
     "l_shipinstruct": {{ json $l.ShipInstruct }},
     "l_shipmode": {{ json $l.ShipMode }},
     "l_comment": {{ json $l.Comment }},
-    "l_revenue": {{ $l.Revenue }}
+    "l_disc_price": {{ $l.DiscPrice }},
+    "l_charge": {{ $l.Charge }}
+    "l_revenue": {{ $l.Revenue }},
 }
 """
 upsert_template = """
@@ -63,10 +68,7 @@ upsert_template = """
             "filterable": false
         },
         "l_returnflag": "string",
-        "l_linestatus": {
-            "type": "string",
-            "filterable": false
-        },
+        "l_linestatus": "string",
         "l_shipdate": "datetime",
         "l_commitdate": "datetime",
         "l_receiptdate": "datetime",
@@ -76,11 +78,40 @@ upsert_template = """
             "type": "string",
             "filterable": false
         },
-        "l_revenue": {
+        "l_disc_price": {
+            "type": "float",
+            "filterable": false
+        },
+        "l_charge": {
             "type": "float",
             "filterable": false
         }
+        "l_revenue": {
+            "type": "float",
+            "filterable": false
+        },
     }
+}
+"""
+
+[workload.query.q1]
+qps = 1
+concurrency = 1
+datasource = "TPCHLineitemSF10"
+template = """
+{
+    "aggregate_by": {
+        "sum_qty": ["Sum", "l_quantity"],
+        "sum_base_price": ["Sum", "l_extendedprice"],
+        "sum_disc_price": ["Sum", "l_disc_price"],
+        "sum_charge": ["Sum", "l_charge"],
+        "avg_qty": ["Avg", "l_quantity"],
+        "avg_price": ["Avg", "l_extendedprice"],
+        "avg_disc": ["Avg", "l_discount"],
+        "count_order": ["Count"]
+    },
+    "group_by": ["l_returnflag", "l_linestatus"],
+    "filters": ["l_shipdate", "Lte", "1998-09-02T00:00:00Z"]
 }
 """
 

--- a/benchmarks/tpch-sf10.toml
+++ b/benchmarks/tpch-sf10.toml
@@ -39,8 +39,8 @@ document_template = """
     "l_shipmode": {{ json $l.ShipMode }},
     "l_comment": {{ json $l.Comment }},
     "l_disc_price": {{ $l.DiscPrice }},
-    "l_charge": {{ $l.Charge }}
-    "l_revenue": {{ $l.Revenue }},
+    "l_charge": {{ $l.Charge }},
+    "l_revenue": {{ $l.Revenue }}
 }
 """
 upsert_template = """
@@ -85,11 +85,11 @@ upsert_template = """
         "l_charge": {
             "type": "float",
             "filterable": false
-        }
+        },
         "l_revenue": {
             "type": "float",
             "filterable": false
-        },
+        }
     }
 }
 """

--- a/pkg/datasource/datasource.go
+++ b/pkg/datasource/datasource.go
@@ -24,13 +24,14 @@ const (
 	DatasourceCohereWikipediaEmbeddings Kind = "CohereWikipediaEmbeddings"
 	DatasourceCohereMSMarco             Kind = "CohereMSMarco"
 	DatasourceDeep1B                    Kind = "Deep1B"
+	DatasourceTPCHLineitemSF1           Kind = "TPCHLineitemSF1"
 	DatasourceTPCHLineitemSF10          Kind = "TPCHLineitemSF10"
 )
 
 // Valid returns true if the value is a known datasource ID.
 func (v Kind) Valid() bool {
 	switch v {
-	case DatasourceRandom, DatasourceCohereWikipediaEmbeddings, DatasourceCohereMSMarco, DatasourceDeep1B, DatasourceTPCHLineitemSF10:
+	case DatasourceRandom, DatasourceCohereWikipediaEmbeddings, DatasourceCohereMSMarco, DatasourceDeep1B, DatasourceTPCHLineitemSF1, DatasourceTPCHLineitemSF10:
 		return true
 	default:
 		return false
@@ -42,7 +43,7 @@ func (v Kind) Valid() bool {
 func (v *Kind) UnmarshalText(text []byte) error {
 	s := Kind(strings.TrimSpace(string(text)))
 	if !s.Valid() {
-		return fmt.Errorf("data source must be one of %q, %q, %q, %q, or %q", DatasourceRandom, DatasourceCohereWikipediaEmbeddings, DatasourceCohereMSMarco, DatasourceDeep1B, DatasourceTPCHLineitemSF10)
+		return fmt.Errorf("data source must be one of %q, %q, %q, %q, %q, or %q", DatasourceRandom, DatasourceCohereWikipediaEmbeddings, DatasourceCohereMSMarco, DatasourceDeep1B, DatasourceTPCHLineitemSF1, DatasourceTPCHLineitemSF10)
 	}
 	*v = s
 	return nil
@@ -73,6 +74,8 @@ func Make(ctx context.Context, src Kind, cfg Config) Source {
 		return CohereMSMarco(ctx, cfg)
 	case DatasourceDeep1B:
 		return Deep1B(ctx, cfg)
+	case DatasourceTPCHLineitemSF1:
+		return TPCHLineitem(ctx, 1)
 	case DatasourceTPCHLineitemSF10:
 		return TPCHLineitem(ctx, 10)
 	default:

--- a/pkg/datasource/tpch.go
+++ b/pkg/datasource/tpch.go
@@ -32,8 +32,12 @@ type tpchLineitemSource struct {
 
 var _ Source = (*tpchLineitemSource)(nil)
 
-// lineitemRow is one TPC-H lineitem, plus the non-spec l_revenue attribute
-// (l_extendedprice * l_discount) used to express query 6 as a Sum aggregation.
+// lineitemRow is one TPC-H lineitem, plus non-spec computed attributes used to
+// express TPC-H aggregations against turbopuffer:
+//
+//	l_disc_price = l_extendedprice * (1 - l_discount)
+//	l_charge     = l_extendedprice * (1 - l_discount) * (1 + l_tax)
+//	l_revenue    = l_extendedprice * l_discount
 type lineitemRow struct {
 	OrderKey      int64
 	PartKey       int64
@@ -51,6 +55,8 @@ type lineitemRow struct {
 	ShipInstruct  string
 	ShipMode      string
 	Comment       string
+	DiscPrice     float64
+	Charge        float64
 	Revenue       float64
 }
 
@@ -124,6 +130,7 @@ func lineitemFromDBGen(line *dbgen.LineItem) lineitemRow {
 	extendedPrice := float64(line.EPrice) / 100.0
 	discount := float64(line.Discount) / 100.0
 	tax := float64(line.Tax) / 100.0
+	discPrice := extendedPrice * (1 - discount)
 	return lineitemRow{
 		OrderKey:      int64(line.OKey),
 		PartKey:       int64(line.PartKey),
@@ -141,6 +148,8 @@ func lineitemFromDBGen(line *dbgen.LineItem) lineitemRow {
 		ShipInstruct:  line.ShipInstruct,
 		ShipMode:      line.ShipMode,
 		Comment:       line.Comment,
+		DiscPrice:     discPrice,
+		Charge:        discPrice * (1 + tax),
 		Revenue:       extendedPrice * discount,
 	}
 }

--- a/pkg/datasource/tpch_test.go
+++ b/pkg/datasource/tpch_test.go
@@ -35,6 +35,14 @@ func TestTPCHLineitemSF1(t *testing.T) {
 	if math.Abs(first.Discount-0.04) > 1e-9 {
 		t.Fatalf("unexpected discount: %v", first.Discount)
 	}
+	wantDiscPrice := first.ExtendedPrice * (1 - first.Discount)
+	if math.Abs(first.DiscPrice-wantDiscPrice) > 1e-9 {
+		t.Fatalf("l_disc_price mismatch: got %v want %v", first.DiscPrice, wantDiscPrice)
+	}
+	wantCharge := wantDiscPrice * (1 + first.Tax)
+	if math.Abs(first.Charge-wantCharge) > 1e-9 {
+		t.Fatalf("l_charge mismatch: got %v want %v", first.Charge, wantCharge)
+	}
 	if math.Abs(first.Revenue-first.ExtendedPrice*first.Discount) > 1e-9 {
 		t.Fatalf("l_revenue mismatch: got %v want %v", first.Revenue, first.ExtendedPrice*first.Discount)
 	}
@@ -49,6 +57,12 @@ func TestTPCHLineitemSF1(t *testing.T) {
 		row := lineitemFn()
 		if row.OrderKey != 1 || row.LineNumber != int64(i) {
 			t.Fatalf("row %d: got orderkey=%d linenumber=%d", i, row.OrderKey, row.LineNumber)
+		}
+		if math.Abs(row.DiscPrice-row.ExtendedPrice*(1-row.Discount)) > 1e-9 {
+			t.Fatalf("row %d: l_disc_price mismatch", i)
+		}
+		if math.Abs(row.Charge-row.DiscPrice*(1+row.Tax)) > 1e-9 {
+			t.Fatalf("row %d: l_charge mismatch", i)
 		}
 		if math.Abs(row.Revenue-row.ExtendedPrice*row.Discount) > 1e-9 {
 			t.Fatalf("row %d: l_revenue mismatch", i)
@@ -77,15 +91,25 @@ func TestTPCHLineitemSF1(t *testing.T) {
 	}
 }
 
-func TestTPCHLineitemSF10Kind(t *testing.T) {
-	if !DatasourceTPCHLineitemSF10.Valid() {
-		t.Fatal("TPCHLineitemSF10 should be a valid datasource kind")
-	}
-	src := Make(context.Background(), DatasourceTPCHLineitemSF10, Config{})
-	if _, ok := src.(*tpchLineitemSource); !ok {
-		t.Fatalf("expected *tpchLineitemSource, got %T", src)
-	}
-	if src.(*tpchLineitemSource).scale != 10 {
-		t.Fatalf("expected scale 10, got %d", src.(*tpchLineitemSource).scale)
+func TestTPCHLineitemKind(t *testing.T) {
+	for _, tc := range []struct {
+		kind  Kind
+		scale int64
+	}{
+		{DatasourceTPCHLineitemSF1, 1},
+		{DatasourceTPCHLineitemSF10, 10},
+	} {
+		t.Run(string(tc.kind), func(t *testing.T) {
+			if !tc.kind.Valid() {
+				t.Fatalf("%s should be a valid datasource kind", tc.kind)
+			}
+			src := Make(context.Background(), tc.kind, Config{})
+			if _, ok := src.(*tpchLineitemSource); !ok {
+				t.Fatalf("expected *tpchLineitemSource, got %T", src)
+			}
+			if src.(*tpchLineitemSource).scale != tc.scale {
+				t.Fatalf("expected scale %d, got %d", tc.scale, src.(*tpchLineitemSource).scale)
+			}
+		})
 	}
 }


### PR DESCRIPTION
https://github.com/lushl9301/TPCH-in-English/blob/master/tpch-query1.md

https://www.database-doctor.com/posts/tpch-intro

q1 needs discounted price and charge precomputed, and sf1 is a cheaper way to iterate on the same queries.