### PR TITLE
nightly: stop requiring unused local SSDs

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+NODE_NAME="github-actions-tpuf-benchmark"
+PROJECT="turbopuffer-test"
+ZONES=(us-central1-a us-central1-b us-central1-c us-central1-f)
+
+INSTANCE_MISSING=2
+
+instance_zone() {
+	local zones
+	if ! zones=$(gcloud compute instances list --project=$PROJECT --filter="name=$NODE_NAME" --format='value(zone)'); then
+		echo "Failed to look up instance $NODE_NAME in project $PROJECT" >&2
+		return 1
+	fi
+	if [ -z "$zones" ]; then
+		echo "Instance $NODE_NAME not found in project $PROJECT" >&2
+		return $INSTANCE_MISSING
+	fi
+	if [ "$(echo "$zones" | wc -l)" -gt 1 ]; then
+		echo "Multiple instances named $NODE_NAME found in zones: $(echo "$zones" | tr '\n' ' ')" >&2
+		return 1
+	fi
+	echo "$zones"
+}

--- a/scripts/create-instance.sh
+++ b/scripts/create-instance.sh
@@ -1,35 +1,59 @@
 #!/bin/bash
 
-set -ex
+set -e
 
-NODE_NAME="github-actions-tpuf-benchmark"
-PROJECT="turbopuffer-test"
-ZONE="us-central1-c"
+source "$(dirname "$0")/common.sh"
+
 # https://cloud.google.com/compute/vm-instance-pricing
 # https://cloud.google.com/compute/docs/general-purpose-machines
 DISK_TYPE="hyperdisk-balanced"
-MACHINE_TYPE="c4a-standard-32-lssd"
+MACHINE_TYPE="c4a-standard-32"
 IMAGE_SUFFIX="-arm64"
 
-gcloud compute instances create $NODE_NAME \
-	--project=$PROJECT \
-	--zone=$ZONE \
-	--machine-type=$MACHINE_TYPE \
-    --no-restart-on-failure \
-	--network-interface=network-tier=PREMIUM,stack-type=IPV4_ONLY,subnet=default \
-	--maintenance-policy=MIGRATE \
-	--provisioning-model=STANDARD \
-	--local-ssd-recovery-timeout=1 \
-	--instance-termination-action=STOP \
-	--max-run-duration=10800s \
-	--no-service-account \
-	--no-scopes \
-	"${DISK_ARGS[@]}" \
-	--create-disk=auto-delete=yes,boot=yes,device-name=$NODE_NAME,image=projects/debian-cloud/global/images/debian-12-bookworm$IMAGE_SUFFIX-v20250910,mode=rw,size=200,type=projects/$PROJECT/zones/$ZONE/diskTypes/$DISK_TYPE \
-	--no-shielded-secure-boot \
-	--shielded-vtpm \
-	--shielded-integrity-monitoring \
-	--tags=github-actions-ssh \
-	--labels=goog-ec-src=vm_add-gcloud \
-	--reservation-affinity=any \
-	--discard-local-ssds-at-termination-timestamp=true
+rc=0
+EXISTING=$(instance_zone) || rc=$?
+if [ $rc -eq 0 ]; then
+	echo "Instance $NODE_NAME already exists in $EXISTING" >&2
+	exit 1
+elif [ $rc -ne $INSTANCE_MISSING ]; then
+	exit $rc
+fi
+
+for ZONE in "${ZONES[@]}"; do
+	echo "Attempting to create instance in $ZONE..."
+	if gcloud compute instances create $NODE_NAME \
+		--project=$PROJECT \
+		--zone=$ZONE \
+		--machine-type=$MACHINE_TYPE \
+		--no-restart-on-failure \
+		--network-interface=network-tier=PREMIUM,stack-type=IPV4_ONLY,subnet=default \
+		--maintenance-policy=MIGRATE \
+		--provisioning-model=STANDARD \
+		--instance-termination-action=STOP \
+		--max-run-duration=21600s \
+		--no-service-account \
+		--no-scopes \
+		--create-disk=auto-delete=yes,boot=yes,device-name=$NODE_NAME,image=projects/debian-cloud/global/images/debian-12-bookworm$IMAGE_SUFFIX-v20250910,mode=rw,size=200,type=projects/$PROJECT/zones/$ZONE/diskTypes/$DISK_TYPE \
+		--no-shielded-secure-boot \
+		--shielded-vtpm \
+		--shielded-integrity-monitoring \
+		--tags=github-actions-ssh \
+		--labels=goog-ec-src=vm_add-gcloud \
+		--reservation-affinity=any; then
+		echo "Created instance in $ZONE"
+		exit 0
+	fi
+	rc=0
+	EXISTING=$(instance_zone) || rc=$?
+	if [ $rc -eq 0 ]; then
+		echo "Create failed but instance exists in $EXISTING; refusing to create another" >&2
+		exit 1
+	elif [ $rc -ne $INSTANCE_MISSING ]; then
+		echo "Create failed and instance lookup was inconclusive; refusing to continue" >&2
+		exit $rc
+	fi
+	echo "Could not create instance in $ZONE, trying next zone..."
+done
+
+echo "Failed to create instance in any zone: ${ZONES[*]}" >&2
+exit 1

--- a/scripts/run-remote.sh
+++ b/scripts/run-remote.sh
@@ -2,9 +2,11 @@
 
 set -ex
 
-NODE_NAME="github-actions-tpuf-benchmark"
-PROJECT="turbopuffer-test"
-ZONE="us-central1-c"
+source "$(dirname "$0")/common.sh"
+
+START_ATTEMPTS=5
+START_RETRY_DELAY=120
+ZONE=$(instance_zone)
 
 SSH="gcloud compute ssh $NODE_NAME --project=$PROJECT --zone=$ZONE --tunnel-through-iap --"
 SCP="gcloud compute scp --project=$PROJECT --zone=$ZONE --tunnel-through-iap"
@@ -21,7 +23,17 @@ fi
 STATUS=$(gcloud compute instances describe $NODE_NAME --project=$PROJECT --zone=$ZONE --format='get(status)')
 if [ "$STATUS" != "RUNNING" ]; then
 	echo "Instance is $STATUS, starting..."
-	gcloud compute instances start $NODE_NAME --project=$PROJECT --zone=$ZONE
+	for attempt in $(seq 1 $START_ATTEMPTS); do
+		if gcloud compute instances start $NODE_NAME --project=$PROJECT --zone=$ZONE; then
+			break
+		fi
+		if [ "$attempt" -eq "$START_ATTEMPTS" ]; then
+			echo "Instance failed to start after $START_ATTEMPTS attempts"
+			exit 1
+		fi
+		echo "Start failed (attempt $attempt/$START_ATTEMPTS), retrying in ${START_RETRY_DELAY}s..."
+		sleep $START_RETRY_DELAY
+	done
 	# Wait for SSH to become available.
 	echo "Waiting for SSH..."
 	for i in $(seq 1 30); do

--- a/scripts/shutdown-instance.sh
+++ b/scripts/shutdown-instance.sh
@@ -2,10 +2,18 @@
 
 set -ex
 
-NODE_NAME="github-actions-tpuf-benchmark"
-PROJECT="turbopuffer-test"
-ZONE="us-central1-c"
+source "$(dirname "$0")/common.sh"
+
+rc=0
+ZONE=$(instance_zone) || rc=$?
+if [ $rc -eq $INSTANCE_MISSING ]; then
+	echo "Nothing to stop."
+	exit 0
+elif [ $rc -ne 0 ]; then
+	echo "Could not determine instance zone; instance may still be running." >&2
+	exit $rc
+fi
 
 # Stop the instance.
 echo "Stopping instance..."
-gcloud compute instances stop $NODE_NAME --project=$PROJECT --zone=$ZONE --discard-local-ssd=true
+gcloud compute instances stop $NODE_NAME --project=$PROJECT --zone=$ZONE


### PR DESCRIPTION
17 of the last 30 nightlies failed with ZONE_RESOURCE_POOL_EXHAUSTED when starting the benchmark VM. The instance asked for a c4a-standard-32-lssd with local SSDs, a shape that is frequently stocked out in us-central1-c; on some days no zone in the region had capacity for it.

The request for local SSDs was an artifact of a previous iteration of the nightly benchmark that ran tpuf locally. We run agaist production and don't need the local SSDs.

Also vibed zonal fallbacks into the script so we can look for stock in alternative zones.